### PR TITLE
Refresh hash_override UUIDs on pt-bound templates for ptabler 2.0

### DIFF
--- a/.changeset/refresh-hash-overrides-ptabler-1.16.md
+++ b/.changeset/refresh-hash-overrides-ptabler-1.16.md
@@ -1,0 +1,14 @@
+---
+"@platforma-open/milaboratories.mixcr-clonotyping-2.workflow": patch
+---
+
+Refresh `hash_override` UUIDs on three workflow templates so their resource identity changes when the underlying ptabler-driven `:pt` API changes its on-disk output.
+
+Affected:
+- `workflow/src/aggregate-by-clonotype-key.tpl.tengo`
+- `workflow/src/process-single-cell.tpl.tengo`
+- `workflow/src/mixcr-export.tpl.tengo`
+
+Each of these imports `@platforma-sdk/workflow-tengo:pt` and therefore goes through `pt.workflow-run` / `pt.import-dir`. With `@platforma-open/milaboratories.software-ptabler` 1.16.0 → 2.0.0 (in `@platforma-sdk/workflow-tengo`), the parquet bytes emitted by `WriteFrame` and the `numberOfBytes` recorded in `DataInfo` change for identical input data. Without refreshing the hash_override UUID, callers would dedupe by the locked identity and reuse pre-bump cached resources whose CIDs no longer match the new output.
+
+Templates that do not import `:pt` (e.g. `mixcr-analyze.tpl.tengo`) are unaffected and intentionally keep their existing UUIDs.

--- a/workflow/src/aggregate-by-clonotype-key.tpl.tengo
+++ b/workflow/src/aggregate-by-clonotype-key.tpl.tengo
@@ -1,4 +1,4 @@
-//tengo:hash_override 8B1CFC68-2542-4C81-8CD4-F927B75F3975
+//tengo:hash_override 2DFA7F87-DAF1-4721-9D09-B5FD6400072C
 
 ll := import("@platforma-sdk/workflow-tengo:ll")
 self := import("@platforma-sdk/workflow-tengo:tpl")

--- a/workflow/src/mixcr-export.tpl.tengo
+++ b/workflow/src/mixcr-export.tpl.tengo
@@ -1,4 +1,4 @@
-//tengo:hash_override E5C1AD4C-B44D-4DE1-BBF1-4CB42ED7579A
+//tengo:hash_override 6ECBA04A-9B6A-4642-A294-72122647A34D
 
 ll := import("@platforma-sdk/workflow-tengo:ll")
 self := import("@platforma-sdk/workflow-tengo:tpl.light")

--- a/workflow/src/process-single-cell.tpl.tengo
+++ b/workflow/src/process-single-cell.tpl.tengo
@@ -1,4 +1,4 @@
-//tengo:hash_override AB9AC8BA-5FFC-40C5-B2F7-AC42181524F5
+//tengo:hash_override 2962BB8D-99D5-45D9-80A4-7694EFFBFDAA
 
 ll := import("@platforma-sdk/workflow-tengo:ll")
 self := import("@platforma-sdk/workflow-tengo:tpl.light")


### PR DESCRIPTION
## Summary

Three workflow templates with `//tengo:hash_override` import `@platforma-sdk/workflow-tengo:pt` and transitively go through `pt.workflow-run` / `pt.import-dir`. With the upcoming `@platforma-open/milaboratories.software-ptabler` 1.16.0 → 2.0.0 bump (pulled in via `@platforma-sdk/workflow-tengo`), ptabler's `WriteFrame` emits a different parquet byte layout (Page Index, bloom on every column, DataPage v2) and a different `Stats.numberOfBytes` (now data-only `SUM(LENGTH(CAST(col AS BLOB)))` instead of `total_uncompressed_size`). Identical input data therefore produces different on-disk output and a different `DataInfo`.

Without refreshing the `hash_override` UUID, callers would dedupe by the locked identity and reuse pre-bump cached resources whose CIDs no longer match the new output → CID drift in dependent blocks.

| Template | Old UUID | New UUID |
|---|---|---|
| `workflow/src/aggregate-by-clonotype-key.tpl.tengo` | `8B1CFC68-2542-4C81-8CD4-F927B75F3975` | `2DFA7F87-DAF1-4721-9D09-B5FD6400072C` |
| `workflow/src/process-single-cell.tpl.tengo` | `AB9AC8BA-5FFC-40C5-B2F7-AC42181524F5` | `2962BB8D-99D5-45D9-80A4-7694EFFBFDAA` |
| `workflow/src/mixcr-export.tpl.tengo` | `E5C1AD4C-B44D-4DE1-BBF1-4CB42ED7579A` | `6ECBA04A-9B6A-4642-A294-72122647A34D` |

`mixcr-analyze.tpl.tengo` is intentionally **not** changed — it does not import `:pt` and its transitive dependencies do not reach any `WriteFrame` producer in workflow-tengo, so its on-disk output is unchanged by the ptabler bump.

## Trace

The pt-bound set inside `@platforma-sdk/workflow-tengo` was computed by reverse-dep BFS from the WriteFrame producers (`:pt`, `:pt.workflow-run`, `:pt.util`, `:pt.import-dir`, `:pframes.xsv-import-pt`) — 30 modules. Each `hash_override` template here was forward-traversed for its workflow-tengo imports and checked for intersection with that set; results were cross-verified by an independent forward closure.

## Test plan

- [ ] CI green
- [ ] Verify with a downstream block that consumes this workflow's outputs: rerun against the same input, confirm new CIDs appear and pre-bump cached resources are not reused
- [ ] Sanity check: `mixcr-analyze` still produces the same CIDs (unaffected template)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR refreshes the `//tengo:hash_override` UUIDs on the three workflow templates that transitively reach the `WriteFrame` producer via `@platforma-sdk/workflow-tengo:pt`, ensuring their resource identity changes alongside the upcoming ptabler 1.16 → 2.0 bump that alters on-disk parquet output and `DataInfo.numberOfBytes` semantics.

- **Three templates updated** (`aggregate-by-clonotype-key`, `mixcr-export`, `process-single-cell`) — each was confirmed to import `:pt`; the new UUIDs are globally unique within the repository.
- **`mixcr-analyze.tpl.tengo` intentionally untouched** — it does not import `:pt` or any module in the pt-bound set, and its on-disk output is unaffected by the ptabler bump.
- **Changeset file** names the bump as `ptabler-1.16` in its filename while the PR and body both describe the 2.0 change; minor naming inconsistency but no functional impact.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is a targeted UUID rotation on exactly the three templates whose transitive imports reach ptabler's WriteFrame; the fourth template is correctly left untouched. No logic or schema changes are involved.

All three affected templates were verified to import `@platforma-sdk/workflow-tengo:pt`; the fourth template (`mixcr-analyze`) was confirmed not to import `:pt`, matching the PR's exclusion rationale. The new UUIDs are unique across the repository. The only observation is a minor naming mismatch between the changeset filename and the ptabler 2.0 version described in the PR body, which has no functional impact.

The changeset filename `refresh-hash-overrides-ptabler-1.16.md` is the only file worth a second look — its name references "ptabler-1.16" while the PR targets ptabler 2.0.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| workflow/src/aggregate-by-clonotype-key.tpl.tengo | UUID refreshed from 8B1CFC68… to 2DFA7F87…; file imports `@platforma-sdk/workflow-tengo:pt` so it is correctly in scope for the ptabler-bump identity change |
| workflow/src/mixcr-export.tpl.tengo | UUID refreshed from E5C1AD4C… to 6ECBA04A…; file imports `@platforma-sdk/workflow-tengo:pt` so the refresh is correct |
| workflow/src/process-single-cell.tpl.tengo | UUID refreshed from AB9AC8BA… to 2962BB8D…; file imports both `@platforma-sdk/workflow-tengo:pt` and the ptabler software asset directly, so refreshing is correct |
| .changeset/refresh-hash-overrides-ptabler-1.16.md | New changeset entry documenting the UUID refresh; filename references "ptabler-1.16" while the PR targets the ptabler 2.0 bump, which is a minor naming inconsistency |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.changeset/refresh-hash-overrides-ptabler-1.16.md:1
**Changeset filename references old version**

The file is named `refresh-hash-overrides-ptabler-1.16.md`, but the PR title and description consistently describe this as a ptabler **2.0** bump (`1.16.0 → 2.0.0`). Someone browsing the changeset directory later may read "ptabler-1.16" as belonging to the 1.16 release cycle rather than as preparation for 2.0. Consider naming it `refresh-hash-overrides-ptabler-2.0.md` to match the PR narrative.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Refresh hash\_override UUIDs on pt-bound ..."](https://github.com/platforma-open/mixcr-clonotyping/commit/70a0294e833a2efea8ac63d5a7fcd75a381a8b61) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32792455)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->