### PR TITLE
Revert "Fix workflow prepare logic"

### DIFF
--- a/.changeset/shaggy-moles-rest.md
+++ b/.changeset/shaggy-moles-rest.md
@@ -1,0 +1,5 @@
+---
+"@platforma-open/milaboratories.mixcr-clonotyping-2.workflow": patch
+---
+
+Revert workflow prepare changes

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ catalogs:
       specifier: 4.7.0-347-develop
       version: 4.7.0-347-develop
     '@platforma-sdk/block-tools':
-      specifier: 2.7.13
-      version: 2.7.13
+      specifier: 2.8.2
+      version: 2.8.2
     '@platforma-sdk/eslint-config':
       specifier: 1.2.0
       version: 1.2.0
@@ -37,8 +37,8 @@ catalogs:
       specifier: 1.63.1
       version: 1.63.1
     '@platforma-sdk/tengo-builder':
-      specifier: 2.5.7
-      version: 2.5.7
+      specifier: 3.0.2
+      version: 3.0.2
     '@platforma-sdk/test':
       specifier: 1.63.9
       version: 1.63.9
@@ -100,7 +100,7 @@ importers:
         version: 2.29.8(@types/node@24.10.2)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.7.13
+        version: 2.8.2
       js-yaml:
         specifier: 'catalog:'
         version: 4.1.1
@@ -131,7 +131,7 @@ importers:
     devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.7.13
+        version: 2.8.2
 
   model:
     dependencies:
@@ -150,7 +150,7 @@ importers:
         version: 1.2.3
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.7.13
+        version: 2.8.2
       '@platforma-sdk/eslint-config':
         specifier: 'catalog:'
         version: 1.2.0(@eslint/js@9.39.1)(@stylistic/eslint-plugin@2.13.0(eslint@9.39.1)(typescript@5.6.3))(eslint-plugin-n@17.23.1(eslint@9.39.1)(typescript@5.6.3))(eslint-plugin-vue@9.33.0(eslint@9.39.1))(eslint@9.39.1)(globals@15.15.0)(typescript-eslint@8.49.0(eslint@9.39.1)(typescript@5.6.3))(typescript@5.6.3)
@@ -273,7 +273,7 @@ importers:
     devDependencies:
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
-        version: 2.5.7
+        version: 3.0.2
 
 packages:
 
@@ -1002,6 +1002,10 @@ packages:
     resolution: {integrity: sha512-GcxeGHakSLhewbA7hd8YVHnEzyi95UnzcZhgwvRPO+W7/svZc8sAGidAV5xgN/YmVmJfCRl7hfiIcL37+fm0Ew==}
     engines: {node: '>=22'}
 
+  '@milaboratories/helpers@1.14.2':
+    resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
+    engines: {node: '>=22'}
+
   '@milaboratories/pf-driver@1.3.4':
     resolution: {integrity: sha512-cPXJc3Bh43Rt7PsEQ9pMEiqog2QWhTlYvcJiwveUhs1/u2Lb83nLhQdV8pcXRciXsoAa8h0dcfW9WNn2N3RtVg==}
     engines: {node: '>=22.19.0'}
@@ -1027,6 +1031,10 @@ packages:
     resolution: {integrity: sha512-nwqlgbO8LPF2OROheqQDBICVf3O/5ziR2X8KKYNRWBm06odvtI1/V5PdeobHtCicQG587SDzriEUgF+9ZD/Fzg==}
     engines: {node: '>=22.19.0'}
 
+  '@milaboratories/pl-client@3.8.1':
+    resolution: {integrity: sha512-x2Y1xooxtEttIfj60JSGMUDdTsAk3RrmlOmuuytwgq82RfDpAAa1M1XHBfuCUNoAjDP1e6BgU9rk4ZhOMGBf9A==}
+    engines: {node: '>=22.19.0'}
+
   '@milaboratories/pl-config@1.7.17':
     resolution: {integrity: sha512-qqpgWAvKP/nL7GC9oBnAXLJwuib4johKqgKIrTkqiQE14B/HwjLebSAKTQUx9ya2/nDBZyjJbHeXvkmoWyqwrw==}
 
@@ -1037,6 +1045,9 @@ packages:
   '@milaboratories/pl-drivers@1.12.9':
     resolution: {integrity: sha512-zWf76OF5oDlTR6peg/+0eQDgk+kIOYrd2PHzCsg7S2skGGfZLfRl+YhXcSZ6tB5QmXHJeRWYE+Nf2o72rT2JAQ==}
     engines: {node: '>=22'}
+
+  '@milaboratories/pl-error-like@1.12.10':
+    resolution: {integrity: sha512-iHmnLG5lxJqcymUmEL8onCDGEADk1S/5RNACQ5yfTCNcCkUc+7hYrDHQpFmWXPPGC9sG+NTBxt4wr5m8UsLm2g==}
 
   '@milaboratories/pl-error-like@1.12.5':
     resolution: {integrity: sha512-opYP4OrB6JBMsH9RMRmAH44+MG7PWiV08dHW9+RsXGOaqX+rYXs9TTBXYRhlVMDLwwefSKzelvDg8HL748aM+A==}
@@ -1057,6 +1068,9 @@ packages:
   '@milaboratories/pl-model-backend@1.2.7':
     resolution: {integrity: sha512-2ComwsRAgXY635He1IpR00vSutQh57V7ziz3Ow//2q1SbVCgY654SMsn3HvPbOqyJ1LGoY5+HENzjoVOldwp6w==}
 
+  '@milaboratories/pl-model-backend@1.3.2':
+    resolution: {integrity: sha512-1w4Jcl2vk7w8foWztKthDryQCPrkefW+5hXIwSNsNIB40o0v83p4zoqMGBrrm9b2MJUPoFyliTkAsp+J1UQu9g==}
+
   '@milaboratories/pl-model-common@1.21.9':
     resolution: {integrity: sha512-0n8oq0e4ZqbMJIzVnP478BGT86vB4gNSRoDic1ai7bNwMiO+jtNSOwGMwR0mFeRLqXidSLcfDxiEMXmak34f7g==}
 
@@ -1066,8 +1080,8 @@ packages:
   '@milaboratories/pl-model-common@1.31.1':
     resolution: {integrity: sha512-MLQvhXXFOykABZr8aVgzt5x0htT7ye4cvvnVy0TgOITXpct+lEmWvaVj29zirK/0VFw7wnTXDGnLwusr77NZFA==}
 
-  '@milaboratories/pl-model-common@1.35.0':
-    resolution: {integrity: sha512-IQ/49eFUNl2hnI83Zj9WqxKhEYCmw9TZKwX4yVdzh+6zKY6oPWKo6T4Y/g7oPsy94WA+yJGcN7o8wN0M7y005Q==}
+  '@milaboratories/pl-model-common@1.42.0':
+    resolution: {integrity: sha512-ttX9OcQ9kgEhgyXZNkC7+vtsCaxjz+uNwmU8d2LlA56cpWgWV9WONi91w8nCRGFf9WboSgUVVaFj2XxiT9QHXQ==}
 
   '@milaboratories/pl-model-middle-layer@1.15.0':
     resolution: {integrity: sha512-uYb/H+rYWSY4IckYxKClQF6yLv+yOJMqtIfJusd7MuCn29HYeQLMruowNaf9A/O35bFx5gqAeiF7XDCn2iQHNA==}
@@ -1075,8 +1089,8 @@ packages:
   '@milaboratories/pl-model-middle-layer@1.16.3':
     resolution: {integrity: sha512-XLZEC3POgUMNNjXr3Pudh7gx2CXZygeskxuQCyPfj4c8Fi35+kAfH9VBpNZD1koiT2n+x5QZyS3RpzcAddQTnQ==}
 
-  '@milaboratories/pl-model-middle-layer@1.18.4':
-    resolution: {integrity: sha512-wn4J8wELpI8nV2yzeeoiDvX5Riz4vnvE9/98m9dBvowDhYRmdBralInPYQkX1do8jGmqlwLMRx9KNV+X4ugQMw==}
+  '@milaboratories/pl-model-middle-layer@1.20.0':
+    resolution: {integrity: sha512-RGEJD0avNEBejl1SjCqn7RWNiK15xCNWMXfNziiHUcG4n+QxYm1sk5AezfWsKE3j3y1HdzZnYaoGto9Z1RoV7A==}
 
   '@milaboratories/pl-tree@1.9.8':
     resolution: {integrity: sha512-gtXd72GEugEi9fBIHY9n6N3a5TpdLZFg+Q0OUBwE9/aREmYjeZifRtrZi8yIe67brdr5d0OojibRcw3VkH2umQ==}
@@ -1109,8 +1123,15 @@ packages:
   '@milaboratories/ts-helpers-oclif@1.1.40':
     resolution: {integrity: sha512-0I5vpgfUYT0sfADFTy5iVeCNPPBnJcZzd6enmbxYp2YczV1EdPDVhv+BbLIN3oLLMKpADJJ485QEXhN2i39Yvg==}
 
+  '@milaboratories/ts-helpers-oclif@1.1.41':
+    resolution: {integrity: sha512-rpn1jB2b6p4hcw4Y2iuLM/9X9zqGXacRL1RbZMaB6ebk+2bnmH3CtmfJJdBWW1wfsP80HqmRV8iQrfCI1kzFDA==}
+
   '@milaboratories/ts-helpers@1.8.1':
     resolution: {integrity: sha512-eIDBzT9quzL3T7ivQn2BCKlsCqnCoSjtMSWSyFmdzPyDAY2OXb6sBjcYcSDdYLQAn2BANBEevii2Tp+WYAzIQw==}
+    engines: {node: '>=22.19.0'}
+
+  '@milaboratories/ts-helpers@1.8.2':
+    resolution: {integrity: sha512-bQHcEAeJXyV95Gyk0yoRS5t3M71mFaNG+SsY2o+i4GDDeByUXBiF+T5A0elc/rCyLK6NNlOblou0DHBYOiW3pQ==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/uikit@2.11.7':
@@ -1455,12 +1476,12 @@ packages:
   '@platforma-open/milaboratories.software-small-binaries@2.0.2':
     resolution: {integrity: sha512-/ViK6kJDjCL/0jBFuEqLwSrpLK4afnR4XiHFOvIlaiYgWHeRU4Gw3aCSMRo6lhG3r6YeeWBqZ9FCkGKKy3TPvg==}
 
-  '@platforma-sdk/block-tools@2.7.13':
-    resolution: {integrity: sha512-Gss2jM5UUGbm6fSpFUHqWm8u2bH7DYHIrmjS42gxgF0L+Eiori0W7LDqGnjMNZ+eH5+KEo6j+WuRBu6dIDGvyg==}
-    hasBin: true
-
   '@platforma-sdk/block-tools@2.7.6':
     resolution: {integrity: sha512-4dAN07/af5wwaFU9oN7LRJ19K3G7DWuVaLpkWpz68/QRvhiTiCm/5BnRYsaO8qQHckpTF+WPulNIQBgBmzzu+Q==}
+    hasBin: true
+
+  '@platforma-sdk/block-tools@2.8.2':
+    resolution: {integrity: sha512-9+rqqx0XAWNfo+P6rA95UqRFMLZckbZ3W/xPi53zt+vYqgCLehZM+KnGROOk0w5NxiTsudB2JJSbeM2WyQUnxQ==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
@@ -1485,8 +1506,8 @@ packages:
   '@platforma-sdk/model@1.63.1':
     resolution: {integrity: sha512-Ma1PEz3yZw6Jbo23BEUrZcO/8q15FU0DEtcjxObobVqXFoS0o4yCNPDxWytksiT2JL3G8F+Ic+k/wHYZ/Fbd0Q==}
 
-  '@platforma-sdk/tengo-builder@2.5.7':
-    resolution: {integrity: sha512-zn2p+/jMEV0Mbo8ejcgtMhITu4qimRn50Bh9txzmzmXATH/xNLwreWFnyGFTkvTUNhmZrYRm6BHS9fW7+Qu8sg==}
+  '@platforma-sdk/tengo-builder@3.0.2':
+    resolution: {integrity: sha512-v1g1SOtZDrCuIcvrlqwsaf3stCHsrV8wuoOgl8ok67fX+9cJtT/QU6NIv+qfog0uukHEjHxourwcu+w0Moz6GQ==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -4573,6 +4594,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vite-plugin-commonjs@0.10.4:
@@ -6014,6 +6036,8 @@ snapshots:
 
   '@milaboratories/helpers@1.14.1': {}
 
+  '@milaboratories/helpers@1.14.2': {}
+
   '@milaboratories/pf-driver@1.3.4(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
       '@milaboratories/helpers': 1.14.1
@@ -6082,6 +6106,24 @@ snapshots:
       utility-types: 3.11.0
       yaml: 2.8.2
 
+  '@milaboratories/pl-client@3.8.1':
+    dependencies:
+      '@grpc/grpc-js': 1.13.4
+      '@milaboratories/pl-http': 1.2.4
+      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/ts-helpers': 1.8.2
+      '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
+      '@protobuf-ts/runtime': 2.11.1
+      '@protobuf-ts/runtime-rpc': 2.11.1
+      canonicalize: 2.1.0
+      denque: 2.1.0
+      long: 5.3.2
+      lru-cache: 11.2.4
+      openapi-fetch: 0.15.0
+      undici: 7.16.0
+      utility-types: 3.11.0
+      yaml: 2.8.2
+
   '@milaboratories/pl-config@1.7.17':
     dependencies:
       '@milaboratories/ts-helpers': 1.8.1
@@ -6126,6 +6168,11 @@ snapshots:
       - bare-buffer
       - react-native-b4a
       - supports-color
+
+  '@milaboratories/pl-error-like@1.12.10':
+    dependencies:
+      json-stringify-safe: 5.0.1
+      zod: 3.25.76
 
   '@milaboratories/pl-error-like@1.12.5':
     dependencies:
@@ -6194,6 +6241,12 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.23.8
 
+  '@milaboratories/pl-model-backend@1.3.2':
+    dependencies:
+      '@milaboratories/pl-client': 3.8.1
+      canonicalize: 2.1.0
+      zod: 3.25.76
+
   '@milaboratories/pl-model-common@1.21.9':
     dependencies:
       '@milaboratories/pl-error-like': 1.12.5
@@ -6214,10 +6267,10 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.23.8
 
-  '@milaboratories/pl-model-common@1.35.0':
+  '@milaboratories/pl-model-common@1.42.0':
     dependencies:
-      '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pl-error-like': 1.12.9
+      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/pl-error-like': 1.12.10
       canonicalize: 2.1.0
       zod: 3.25.76
 
@@ -6237,10 +6290,10 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.23.8
 
-  '@milaboratories/pl-model-middle-layer@1.18.4':
+  '@milaboratories/pl-model-middle-layer@1.20.0':
     dependencies:
-      '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pl-model-common': 1.35.0
+      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/pl-model-common': 1.42.0
       es-toolkit: 1.42.0
       utility-types: 3.11.0
       zod: 3.25.76
@@ -6316,9 +6369,20 @@ snapshots:
       '@milaboratories/ts-helpers': 1.8.1
       '@oclif/core': 4.8.0
 
+  '@milaboratories/ts-helpers-oclif@1.1.41':
+    dependencies:
+      '@milaboratories/ts-helpers': 1.8.2
+      '@oclif/core': 4.8.0
+
   '@milaboratories/ts-helpers@1.8.1':
     dependencies:
       '@milaboratories/helpers': 1.14.1
+      canonicalize: 2.1.0
+      denque: 2.1.0
+
+  '@milaboratories/ts-helpers@1.8.2':
+    dependencies:
+      '@milaboratories/helpers': 1.14.2
       canonicalize: 2.1.0
       denque: 2.1.0
 
@@ -6688,27 +6752,6 @@ snapshots:
       '@platforma-open/milaboratories.software-small-binaries.mnz-client': 1.6.3
       '@platforma-open/milaboratories.software-small-binaries.table-converter': 1.3.3
 
-  '@platforma-sdk/block-tools@2.7.13':
-    dependencies:
-      '@aws-sdk/client-s3': 3.859.0
-      '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.35.0
-      '@milaboratories/pl-model-middle-layer': 1.18.4
-      '@milaboratories/resolve-helper': 1.1.3
-      '@milaboratories/ts-helpers': 1.8.1
-      '@milaboratories/ts-helpers-oclif': 1.1.40
-      '@oclif/core': 4.8.0
-      '@platforma-sdk/blocks-deps-updater': 2.2.0
-      canonicalize: 2.1.0
-      lru-cache: 11.2.4
-      mime-types: 2.1.35
-      tar: 7.5.2
-      undici: 7.16.0
-      yaml: 2.8.2
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - aws-crt
-
   '@platforma-sdk/block-tools@2.7.6':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
@@ -6727,6 +6770,28 @@ snapshots:
       undici: 7.16.0
       yaml: 2.8.2
       zod: 3.23.8
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@platforma-sdk/block-tools@2.8.2':
+    dependencies:
+      '@aws-sdk/client-s3': 3.859.0
+      '@milaboratories/pl-http': 1.2.4
+      '@milaboratories/pl-model-backend': 1.3.2
+      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-middle-layer': 1.20.0
+      '@milaboratories/resolve-helper': 1.1.3
+      '@milaboratories/ts-helpers': 1.8.2
+      '@milaboratories/ts-helpers-oclif': 1.1.41
+      '@oclif/core': 4.8.0
+      '@platforma-sdk/blocks-deps-updater': 2.2.0
+      canonicalize: 2.1.0
+      lru-cache: 11.2.4
+      mime-types: 2.1.35
+      tar: 7.5.2
+      undici: 7.16.0
+      yaml: 2.8.2
+      zod: 3.25.76
     transitivePeerDependencies:
       - aws-crt
 
@@ -6768,12 +6833,12 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.23.8
 
-  '@platforma-sdk/tengo-builder@2.5.7':
+  '@platforma-sdk/tengo-builder@3.0.2':
     dependencies:
-      '@milaboratories/pl-model-backend': 1.2.7
+      '@milaboratories/pl-model-backend': 1.3.2
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/tengo-tester': 1.6.4
-      '@milaboratories/ts-helpers': 1.8.1
+      '@milaboratories/ts-helpers': 1.8.2
       '@oclif/core': 4.8.0
       winston: 3.19.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ catalogs:
       specifier: 4.7.0-347-develop
       version: 4.7.0-347-develop
     '@platforma-sdk/block-tools':
-      specifier: 2.8.2
-      version: 2.8.2
+      specifier: 2.7.13
+      version: 2.7.13
     '@platforma-sdk/eslint-config':
       specifier: 1.2.0
       version: 1.2.0
@@ -37,8 +37,8 @@ catalogs:
       specifier: 1.63.1
       version: 1.63.1
     '@platforma-sdk/tengo-builder':
-      specifier: 3.0.2
-      version: 3.0.2
+      specifier: 2.5.7
+      version: 2.5.7
     '@platforma-sdk/test':
       specifier: 1.63.9
       version: 1.63.9
@@ -100,7 +100,7 @@ importers:
         version: 2.29.8(@types/node@24.10.2)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.8.2
+        version: 2.7.13
       js-yaml:
         specifier: 'catalog:'
         version: 4.1.1
@@ -131,7 +131,7 @@ importers:
     devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.8.2
+        version: 2.7.13
 
   model:
     dependencies:
@@ -150,7 +150,7 @@ importers:
         version: 1.2.3
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.8.2
+        version: 2.7.13
       '@platforma-sdk/eslint-config':
         specifier: 'catalog:'
         version: 1.2.0(@eslint/js@9.39.1)(@stylistic/eslint-plugin@2.13.0(eslint@9.39.1)(typescript@5.6.3))(eslint-plugin-n@17.23.1(eslint@9.39.1)(typescript@5.6.3))(eslint-plugin-vue@9.33.0(eslint@9.39.1))(eslint@9.39.1)(globals@15.15.0)(typescript-eslint@8.49.0(eslint@9.39.1)(typescript@5.6.3))(typescript@5.6.3)
@@ -273,7 +273,7 @@ importers:
     devDependencies:
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
-        version: 3.0.2
+        version: 2.5.7
 
 packages:
 
@@ -1002,10 +1002,6 @@ packages:
     resolution: {integrity: sha512-GcxeGHakSLhewbA7hd8YVHnEzyi95UnzcZhgwvRPO+W7/svZc8sAGidAV5xgN/YmVmJfCRl7hfiIcL37+fm0Ew==}
     engines: {node: '>=22'}
 
-  '@milaboratories/helpers@1.14.2':
-    resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
-    engines: {node: '>=22'}
-
   '@milaboratories/pf-driver@1.3.4':
     resolution: {integrity: sha512-cPXJc3Bh43Rt7PsEQ9pMEiqog2QWhTlYvcJiwveUhs1/u2Lb83nLhQdV8pcXRciXsoAa8h0dcfW9WNn2N3RtVg==}
     engines: {node: '>=22.19.0'}
@@ -1031,10 +1027,6 @@ packages:
     resolution: {integrity: sha512-nwqlgbO8LPF2OROheqQDBICVf3O/5ziR2X8KKYNRWBm06odvtI1/V5PdeobHtCicQG587SDzriEUgF+9ZD/Fzg==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-client@3.8.1':
-    resolution: {integrity: sha512-x2Y1xooxtEttIfj60JSGMUDdTsAk3RrmlOmuuytwgq82RfDpAAa1M1XHBfuCUNoAjDP1e6BgU9rk4ZhOMGBf9A==}
-    engines: {node: '>=22.19.0'}
-
   '@milaboratories/pl-config@1.7.17':
     resolution: {integrity: sha512-qqpgWAvKP/nL7GC9oBnAXLJwuib4johKqgKIrTkqiQE14B/HwjLebSAKTQUx9ya2/nDBZyjJbHeXvkmoWyqwrw==}
 
@@ -1045,9 +1037,6 @@ packages:
   '@milaboratories/pl-drivers@1.12.9':
     resolution: {integrity: sha512-zWf76OF5oDlTR6peg/+0eQDgk+kIOYrd2PHzCsg7S2skGGfZLfRl+YhXcSZ6tB5QmXHJeRWYE+Nf2o72rT2JAQ==}
     engines: {node: '>=22'}
-
-  '@milaboratories/pl-error-like@1.12.10':
-    resolution: {integrity: sha512-iHmnLG5lxJqcymUmEL8onCDGEADk1S/5RNACQ5yfTCNcCkUc+7hYrDHQpFmWXPPGC9sG+NTBxt4wr5m8UsLm2g==}
 
   '@milaboratories/pl-error-like@1.12.5':
     resolution: {integrity: sha512-opYP4OrB6JBMsH9RMRmAH44+MG7PWiV08dHW9+RsXGOaqX+rYXs9TTBXYRhlVMDLwwefSKzelvDg8HL748aM+A==}
@@ -1068,9 +1057,6 @@ packages:
   '@milaboratories/pl-model-backend@1.2.7':
     resolution: {integrity: sha512-2ComwsRAgXY635He1IpR00vSutQh57V7ziz3Ow//2q1SbVCgY654SMsn3HvPbOqyJ1LGoY5+HENzjoVOldwp6w==}
 
-  '@milaboratories/pl-model-backend@1.3.2':
-    resolution: {integrity: sha512-1w4Jcl2vk7w8foWztKthDryQCPrkefW+5hXIwSNsNIB40o0v83p4zoqMGBrrm9b2MJUPoFyliTkAsp+J1UQu9g==}
-
   '@milaboratories/pl-model-common@1.21.9':
     resolution: {integrity: sha512-0n8oq0e4ZqbMJIzVnP478BGT86vB4gNSRoDic1ai7bNwMiO+jtNSOwGMwR0mFeRLqXidSLcfDxiEMXmak34f7g==}
 
@@ -1080,8 +1066,8 @@ packages:
   '@milaboratories/pl-model-common@1.31.1':
     resolution: {integrity: sha512-MLQvhXXFOykABZr8aVgzt5x0htT7ye4cvvnVy0TgOITXpct+lEmWvaVj29zirK/0VFw7wnTXDGnLwusr77NZFA==}
 
-  '@milaboratories/pl-model-common@1.42.0':
-    resolution: {integrity: sha512-ttX9OcQ9kgEhgyXZNkC7+vtsCaxjz+uNwmU8d2LlA56cpWgWV9WONi91w8nCRGFf9WboSgUVVaFj2XxiT9QHXQ==}
+  '@milaboratories/pl-model-common@1.35.0':
+    resolution: {integrity: sha512-IQ/49eFUNl2hnI83Zj9WqxKhEYCmw9TZKwX4yVdzh+6zKY6oPWKo6T4Y/g7oPsy94WA+yJGcN7o8wN0M7y005Q==}
 
   '@milaboratories/pl-model-middle-layer@1.15.0':
     resolution: {integrity: sha512-uYb/H+rYWSY4IckYxKClQF6yLv+yOJMqtIfJusd7MuCn29HYeQLMruowNaf9A/O35bFx5gqAeiF7XDCn2iQHNA==}
@@ -1089,8 +1075,8 @@ packages:
   '@milaboratories/pl-model-middle-layer@1.16.3':
     resolution: {integrity: sha512-XLZEC3POgUMNNjXr3Pudh7gx2CXZygeskxuQCyPfj4c8Fi35+kAfH9VBpNZD1koiT2n+x5QZyS3RpzcAddQTnQ==}
 
-  '@milaboratories/pl-model-middle-layer@1.20.0':
-    resolution: {integrity: sha512-RGEJD0avNEBejl1SjCqn7RWNiK15xCNWMXfNziiHUcG4n+QxYm1sk5AezfWsKE3j3y1HdzZnYaoGto9Z1RoV7A==}
+  '@milaboratories/pl-model-middle-layer@1.18.4':
+    resolution: {integrity: sha512-wn4J8wELpI8nV2yzeeoiDvX5Riz4vnvE9/98m9dBvowDhYRmdBralInPYQkX1do8jGmqlwLMRx9KNV+X4ugQMw==}
 
   '@milaboratories/pl-tree@1.9.8':
     resolution: {integrity: sha512-gtXd72GEugEi9fBIHY9n6N3a5TpdLZFg+Q0OUBwE9/aREmYjeZifRtrZi8yIe67brdr5d0OojibRcw3VkH2umQ==}
@@ -1123,15 +1109,8 @@ packages:
   '@milaboratories/ts-helpers-oclif@1.1.40':
     resolution: {integrity: sha512-0I5vpgfUYT0sfADFTy5iVeCNPPBnJcZzd6enmbxYp2YczV1EdPDVhv+BbLIN3oLLMKpADJJ485QEXhN2i39Yvg==}
 
-  '@milaboratories/ts-helpers-oclif@1.1.41':
-    resolution: {integrity: sha512-rpn1jB2b6p4hcw4Y2iuLM/9X9zqGXacRL1RbZMaB6ebk+2bnmH3CtmfJJdBWW1wfsP80HqmRV8iQrfCI1kzFDA==}
-
   '@milaboratories/ts-helpers@1.8.1':
     resolution: {integrity: sha512-eIDBzT9quzL3T7ivQn2BCKlsCqnCoSjtMSWSyFmdzPyDAY2OXb6sBjcYcSDdYLQAn2BANBEevii2Tp+WYAzIQw==}
-    engines: {node: '>=22.19.0'}
-
-  '@milaboratories/ts-helpers@1.8.2':
-    resolution: {integrity: sha512-bQHcEAeJXyV95Gyk0yoRS5t3M71mFaNG+SsY2o+i4GDDeByUXBiF+T5A0elc/rCyLK6NNlOblou0DHBYOiW3pQ==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/uikit@2.11.7':
@@ -1476,12 +1455,12 @@ packages:
   '@platforma-open/milaboratories.software-small-binaries@2.0.2':
     resolution: {integrity: sha512-/ViK6kJDjCL/0jBFuEqLwSrpLK4afnR4XiHFOvIlaiYgWHeRU4Gw3aCSMRo6lhG3r6YeeWBqZ9FCkGKKy3TPvg==}
 
-  '@platforma-sdk/block-tools@2.7.6':
-    resolution: {integrity: sha512-4dAN07/af5wwaFU9oN7LRJ19K3G7DWuVaLpkWpz68/QRvhiTiCm/5BnRYsaO8qQHckpTF+WPulNIQBgBmzzu+Q==}
+  '@platforma-sdk/block-tools@2.7.13':
+    resolution: {integrity: sha512-Gss2jM5UUGbm6fSpFUHqWm8u2bH7DYHIrmjS42gxgF0L+Eiori0W7LDqGnjMNZ+eH5+KEo6j+WuRBu6dIDGvyg==}
     hasBin: true
 
-  '@platforma-sdk/block-tools@2.8.2':
-    resolution: {integrity: sha512-9+rqqx0XAWNfo+P6rA95UqRFMLZckbZ3W/xPi53zt+vYqgCLehZM+KnGROOk0w5NxiTsudB2JJSbeM2WyQUnxQ==}
+  '@platforma-sdk/block-tools@2.7.6':
+    resolution: {integrity: sha512-4dAN07/af5wwaFU9oN7LRJ19K3G7DWuVaLpkWpz68/QRvhiTiCm/5BnRYsaO8qQHckpTF+WPulNIQBgBmzzu+Q==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
@@ -1506,8 +1485,8 @@ packages:
   '@platforma-sdk/model@1.63.1':
     resolution: {integrity: sha512-Ma1PEz3yZw6Jbo23BEUrZcO/8q15FU0DEtcjxObobVqXFoS0o4yCNPDxWytksiT2JL3G8F+Ic+k/wHYZ/Fbd0Q==}
 
-  '@platforma-sdk/tengo-builder@3.0.2':
-    resolution: {integrity: sha512-v1g1SOtZDrCuIcvrlqwsaf3stCHsrV8wuoOgl8ok67fX+9cJtT/QU6NIv+qfog0uukHEjHxourwcu+w0Moz6GQ==}
+  '@platforma-sdk/tengo-builder@2.5.7':
+    resolution: {integrity: sha512-zn2p+/jMEV0Mbo8ejcgtMhITu4qimRn50Bh9txzmzmXATH/xNLwreWFnyGFTkvTUNhmZrYRm6BHS9fW7+Qu8sg==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -4594,7 +4573,6 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vite-plugin-commonjs@0.10.4:
@@ -6036,8 +6014,6 @@ snapshots:
 
   '@milaboratories/helpers@1.14.1': {}
 
-  '@milaboratories/helpers@1.14.2': {}
-
   '@milaboratories/pf-driver@1.3.4(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
       '@milaboratories/helpers': 1.14.1
@@ -6106,24 +6082,6 @@ snapshots:
       utility-types: 3.11.0
       yaml: 2.8.2
 
-  '@milaboratories/pl-client@3.8.1':
-    dependencies:
-      '@grpc/grpc-js': 1.13.4
-      '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/ts-helpers': 1.8.2
-      '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
-      '@protobuf-ts/runtime': 2.11.1
-      '@protobuf-ts/runtime-rpc': 2.11.1
-      canonicalize: 2.1.0
-      denque: 2.1.0
-      long: 5.3.2
-      lru-cache: 11.2.4
-      openapi-fetch: 0.15.0
-      undici: 7.16.0
-      utility-types: 3.11.0
-      yaml: 2.8.2
-
   '@milaboratories/pl-config@1.7.17':
     dependencies:
       '@milaboratories/ts-helpers': 1.8.1
@@ -6168,11 +6126,6 @@ snapshots:
       - bare-buffer
       - react-native-b4a
       - supports-color
-
-  '@milaboratories/pl-error-like@1.12.10':
-    dependencies:
-      json-stringify-safe: 5.0.1
-      zod: 3.25.76
 
   '@milaboratories/pl-error-like@1.12.5':
     dependencies:
@@ -6241,12 +6194,6 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.23.8
 
-  '@milaboratories/pl-model-backend@1.3.2':
-    dependencies:
-      '@milaboratories/pl-client': 3.8.1
-      canonicalize: 2.1.0
-      zod: 3.25.76
-
   '@milaboratories/pl-model-common@1.21.9':
     dependencies:
       '@milaboratories/pl-error-like': 1.12.5
@@ -6267,10 +6214,10 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.23.8
 
-  '@milaboratories/pl-model-common@1.42.0':
+  '@milaboratories/pl-model-common@1.35.0':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-error-like': 1.12.10
+      '@milaboratories/helpers': 1.14.1
+      '@milaboratories/pl-error-like': 1.12.9
       canonicalize: 2.1.0
       zod: 3.25.76
 
@@ -6290,10 +6237,10 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.23.8
 
-  '@milaboratories/pl-model-middle-layer@1.20.0':
+  '@milaboratories/pl-model-middle-layer@1.18.4':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/helpers': 1.14.1
+      '@milaboratories/pl-model-common': 1.35.0
       es-toolkit: 1.42.0
       utility-types: 3.11.0
       zod: 3.25.76
@@ -6331,7 +6278,7 @@ snapshots:
       oxfmt: 0.35.0
       oxlint: 1.43.0
       rolldown: 1.0.0-rc.14
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.14)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.14)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@24.10.2)(rollup@4.53.3)
       typescript: 5.9.3
@@ -6369,20 +6316,9 @@ snapshots:
       '@milaboratories/ts-helpers': 1.8.1
       '@oclif/core': 4.8.0
 
-  '@milaboratories/ts-helpers-oclif@1.1.41':
-    dependencies:
-      '@milaboratories/ts-helpers': 1.8.2
-      '@oclif/core': 4.8.0
-
   '@milaboratories/ts-helpers@1.8.1':
     dependencies:
       '@milaboratories/helpers': 1.14.1
-      canonicalize: 2.1.0
-      denque: 2.1.0
-
-  '@milaboratories/ts-helpers@1.8.2':
-    dependencies:
-      '@milaboratories/helpers': 1.14.2
       canonicalize: 2.1.0
       denque: 2.1.0
 
@@ -6752,6 +6688,27 @@ snapshots:
       '@platforma-open/milaboratories.software-small-binaries.mnz-client': 1.6.3
       '@platforma-open/milaboratories.software-small-binaries.table-converter': 1.3.3
 
+  '@platforma-sdk/block-tools@2.7.13':
+    dependencies:
+      '@aws-sdk/client-s3': 3.859.0
+      '@milaboratories/pl-http': 1.2.4
+      '@milaboratories/pl-model-common': 1.35.0
+      '@milaboratories/pl-model-middle-layer': 1.18.4
+      '@milaboratories/resolve-helper': 1.1.3
+      '@milaboratories/ts-helpers': 1.8.1
+      '@milaboratories/ts-helpers-oclif': 1.1.40
+      '@oclif/core': 4.8.0
+      '@platforma-sdk/blocks-deps-updater': 2.2.0
+      canonicalize: 2.1.0
+      lru-cache: 11.2.4
+      mime-types: 2.1.35
+      tar: 7.5.2
+      undici: 7.16.0
+      yaml: 2.8.2
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - aws-crt
+
   '@platforma-sdk/block-tools@2.7.6':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
@@ -6770,28 +6727,6 @@ snapshots:
       undici: 7.16.0
       yaml: 2.8.2
       zod: 3.23.8
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@platforma-sdk/block-tools@2.8.2':
-    dependencies:
-      '@aws-sdk/client-s3': 3.859.0
-      '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.3.2
-      '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/pl-model-middle-layer': 1.20.0
-      '@milaboratories/resolve-helper': 1.1.3
-      '@milaboratories/ts-helpers': 1.8.2
-      '@milaboratories/ts-helpers-oclif': 1.1.41
-      '@oclif/core': 4.8.0
-      '@platforma-sdk/blocks-deps-updater': 2.2.0
-      canonicalize: 2.1.0
-      lru-cache: 11.2.4
-      mime-types: 2.1.35
-      tar: 7.5.2
-      undici: 7.16.0
-      yaml: 2.8.2
-      zod: 3.25.76
     transitivePeerDependencies:
       - aws-crt
 
@@ -6833,12 +6768,12 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.23.8
 
-  '@platforma-sdk/tengo-builder@3.0.2':
+  '@platforma-sdk/tengo-builder@2.5.7':
     dependencies:
-      '@milaboratories/pl-model-backend': 1.3.2
+      '@milaboratories/pl-model-backend': 1.2.7
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/tengo-tester': 1.6.4
-      '@milaboratories/ts-helpers': 1.8.2
+      '@milaboratories/ts-helpers': 1.8.1
       '@oclif/core': 4.8.0
       winston: 3.19.0
 
@@ -9551,7 +9486,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.14)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3)):
+  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.14)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3)):
     dependencies:
       '@babel/generator': 8.0.0-rc.3
       '@babel/helper-validator-identifier': 8.0.0-rc.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,9 +11,9 @@ catalog:
   '@platforma-sdk/workflow-tengo': 5.12.0
   '@platforma-sdk/model': 1.63.1
   '@platforma-sdk/ui-vue': 1.63.8
-  '@platforma-sdk/tengo-builder': 2.5.7
+  '@platforma-sdk/tengo-builder': 3.0.2
   '@platforma-sdk/package-builder': 3.12.0
-  '@platforma-sdk/block-tools': 2.7.13
+  '@platforma-sdk/block-tools': 2.8.2
   '@platforma-sdk/eslint-config': 1.2.0
 
   '@platforma-sdk/test': 1.63.9

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,9 +11,9 @@ catalog:
   '@platforma-sdk/workflow-tengo': 5.12.0
   '@platforma-sdk/model': 1.63.1
   '@platforma-sdk/ui-vue': 1.63.8
-  '@platforma-sdk/tengo-builder': 3.0.2
+  '@platforma-sdk/tengo-builder': 2.5.7
   '@platforma-sdk/package-builder': 3.12.0
-  '@platforma-sdk/block-tools': 2.8.2
+  '@platforma-sdk/block-tools': 2.7.13
   '@platforma-sdk/eslint-config': 1.2.0
 
   '@platforma-sdk/test': 1.63.9

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -16,11 +16,9 @@ exportReportTpl := assets.importTemplate(":export-report")
 wf.setPreRun(assets.importTemplate(":prerun"))
 
 wf.prepare(func(args){
-	prepared := {}
-	if !is_undefined(args.inputLibrary) {
-		prepared.resolvedLibraryInput = wf.resolve(args.inputLibrary, { errIfMissing: false })
+	return {
+		resolvedLibraryInput: wf.resolve(args.inputLibrary, { errIfMissing: false })
 	}
-	return prepared
 })
 
 wf.body(func(args) {


### PR DESCRIPTION
Reverts platforma-open/mixcr-clonotyping#192

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR reverts #192 ("Fix workflow prepare logic"), rolling back two SDK dependencies and a guard added to the `wf.prepare` callback in the main workflow template.

- `@platforma-sdk/tengo-builder` is downgraded from `3.0.2` → `2.5.7` and `@platforma-sdk/block-tools` from `2.8.2` → `2.7.13`; the lockfile removes all transitive packages that were only needed by the newer versions (e.g. `@milaboratories/pl-client@3.8.1`, `@milaboratories/pl-model-backend@1.3.2`).
- The `is_undefined(args.inputLibrary)` guard in `wf.prepare` is removed, so `wf.resolve` is now called unconditionally regardless of whether the user has configured a library input; the body already guards `args.resolvedLibraryInput` on line 68.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The revert is deliberate but reintroduces an unconditional `wf.resolve` call on a potentially undefined argument; whether that is safe depends entirely on how the older downgraded SDK handles it at runtime.

The functional change in `main.tpl.tengo` removes a guard that was explicitly added by the 'Fix workflow prepare logic' PR. If a user adds the block without configuring a library input, `args.inputLibrary` is undefined and `wf.resolve` is now called unconditionally. The `wf.body` already handles `resolvedLibraryInput` being undefined, so if the older SDK returns `undefined` for an undefined argument with `errIfMissing: false`, this is safe. But if it throws, the block will fail during `prepare` for any user who hasn't set a library — a potentially common scenario.

`workflow/src/main.tpl.tengo` — verify that `wf.resolve(undefined, { errIfMissing: false })` is safe in tengo-builder@2.5.7 before merging.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| workflow/src/main.tpl.tengo | Reverts the conditional guard on `args.inputLibrary`, unconditionally calling `wf.resolve` even when the library input is undefined; safety depends on the older SDK's handling of undefined arguments. |
| pnpm-workspace.yaml | Downgrades `@platforma-sdk/tengo-builder` from 3.0.2 → 2.5.7 and `@platforma-sdk/block-tools` from 2.8.2 → 2.7.13 to roll back the dependency changes introduced in PR #192. |
| pnpm-lock.yaml | Lockfile updated to reflect SDK downgrades; several transitive packages (`@milaboratories/pl-client`, `@milaboratories/pl-model-backend`, etc.) are removed as they were only pulled in by the newer SDK versions. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Block starts] --> B[wf.prepare runs]
    B --> C["wf.resolve(args.inputLibrary, errIfMissing: false)"]
    C -->|args.inputLibrary is defined| D[resolvedLibraryInput = resolved value]
    C -->|args.inputLibrary is undefined| E{"SDK handles undefined?\n(older SDK 2.5.7 / 2.7.13)"}
    E -->|returns undefined safely| F[resolvedLibraryInput = undefined]
    E -->|throws error| G[❌ Runtime error in prepare]
    D --> H[wf.body runs]
    F --> H
    H --> I{"!is_undefined(args.resolvedLibraryInput)?"}
    I -->|true| J[Use library data / spec / species]
    I -->|false| K[Check args.libraryFile instead]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
workflow/src/main.tpl.tengo:18-22
**Unconditional `wf.resolve` call reintroduced**

This revert removes the `!is_undefined(args.inputLibrary)` guard that PR #192 added to prevent calling `wf.resolve` when `inputLibrary` is not yet set. The current code calls `wf.resolve(args.inputLibrary, { errIfMissing: false })` unconditionally; if `args.inputLibrary` is `undefined` at the time `prepare` runs (e.g. when the block is first added before the user configures a library), the behavior of `wf.resolve` on an undefined argument is SDK-version-dependent. The fix in #192 was specifically titled "Fix workflow prepare logic," indicating this was a real breakage. Please confirm that the older downgraded SDK versions (`tengo-builder@2.5.7`, `block-tools@2.7.13`) handle `wf.resolve(undefined, { errIfMissing: false })` safely and return `undefined` rather than throwing.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Revert &quot;Fix workflow prepare logic&quot;"](https://github.com/platforma-open/mixcr-clonotyping/commit/d704a1080e0fa8ea7ac010bcb5e0d792d3456bfc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33273955)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->