### PR TITLE
MILAB-6721: stop double-counting input size in the analyze memory formula

### DIFF
--- a/.changeset/analyze-mem-no-double-count.md
+++ b/.changeset/analyze-mem-no-double-count.md
@@ -1,0 +1,16 @@
+---
+"@platforma-open/milaboratories.mixcr-clonotyping-2.workflow": patch
+---
+
+Analyze memory request no longer double-counts input size on top of the memory floor.
+
+The per-analysis baseline (64 / 110 / 192 GiB) is already a total-memory value for
+the run, so adding a size-derived term on top of it counted the input twice — a
+110 GiB preset with 31.75 GiB of reads asked for 237 GiB instead of 127 GiB. The
+request is now `clamp(4 x size, baseMemGiB, 256 GiB)`: the baseline acts purely as
+the lower bound it was always meant to be. Small inputs still get the full floor,
+and the 256 GiB cap and the "Advanced Settings" override are unchanged.
+
+The formula moved into a `mem-formula` library covered by unit tests, and the
+analyze template's `hash_override` UUID was bumped — that forces a one-time
+recompute of cached analyze results.

--- a/.changeset/analyze-mem-no-double-count.md
+++ b/.changeset/analyze-mem-no-double-count.md
@@ -2,15 +2,15 @@
 "@platforma-open/milaboratories.mixcr-clonotyping-2.workflow": patch
 ---
 
-Analyze memory request no longer double-counts input size on top of the memory floor.
+Analyze counts input size once when sizing its memory request, cutting a 110 GiB
+preset with 31.75 GiB of reads from 237 GiB to 127 GiB.
 
-The per-analysis baseline (64 / 110 / 192 GiB) is already a total-memory value for
-the run, so adding a size-derived term on top of it counted the input twice — a
-110 GiB preset with 31.75 GiB of reads asked for 237 GiB instead of 127 GiB. The
-request is now `clamp(4 x size, baseMemGiB, 256 GiB)`: the baseline acts purely as
-the lower bound it was always meant to be. Small inputs still get the full floor,
-and the 256 GiB cap and the "Advanced Settings" override are unchanged.
+The per-analysis baseline — 64 GiB, or 110 and 192 GiB for contig/cell and MiTool
+presets — is already a total-memory value for the run, so adding a size-derived term
+on top of it counted the input twice. The request is now
+`clamp(4 x size, baseMemGiB, 256 GiB)`, making the baseline the lower bound it was
+always meant to be. Small inputs still receive the full baseline, and both the
+256 GiB cap and the "Advanced Settings" memory override behave as before.
 
-The formula moved into a `mem-formula` library covered by unit tests, and the
-analyze template's `hash_override` UUID was bumped — that forces a one-time
+The analyze template's `hash_override` UUID also changes, which forces a one-time
 recompute of cached analyze results.

--- a/workflow/package.json
+++ b/workflow/package.json
@@ -9,7 +9,7 @@
     "format": "/usr/bin/env emacs --script ./format.el || echo 'No emacs.'",
     "do-pack": "shx rm -f *.tgz && pnpm pack && shx mv *.tgz package.tgz",
     "check": "pl-tengo check",
-    "test": "vitest run --passWithNoTests"
+    "test": "pl-tengo test && vitest run --passWithNoTests"
   },
   "dependencies": {
     "@platforma-open/milaboratories.software-mixcr": "catalog:",

--- a/workflow/src/mem-formula.lib.tengo
+++ b/workflow/src/mem-formula.lib.tengo
@@ -1,0 +1,37 @@
+// Single source of truth for the `mixcr analyze` memory request.
+//
+// The floor is a TOTAL-memory value for the analysis, chosen by which steps the
+// preset runs. size("reads") is the stored (compressed) blob size of the sample's
+// FASTQs — metadata only, no pre-exec pass — so the formula resolves on backends
+// that expose blob size, and falls back to the bare floor on those that do not.
+//
+//     mem = clamp(baseMemGiB + 4 bytes/byte x size, baseMemGiB, 256 GiB)
+
+exec := import("@platforma-sdk/workflow-tengo:exec")
+
+f := exec.formula
+
+// baseMemGiB picks the per-analysis memory floor from the preset's step set.
+// mitool steps dominate; contig or cell assembly is the middle tier.
+baseMemGiB := func(hasMiToolSteps, hasAssembleContigs, hasAssembleCells) {
+	if hasMiToolSteps {
+		return 192
+	}
+	if hasAssembleContigs || hasAssembleCells {
+		return 110
+	}
+	return 64
+}
+
+// memFormula builds the fluent exec.formula node for `.resources({onCPU:{ram}})`.
+memFormula := func(base) {
+	return f.gib(base).
+		plus(f.size("reads").times(4)).
+		between(f.gib(base), f.gib(256)).
+		staticFallback(f.gib(base))
+}
+
+export {
+	baseMemGiB: baseMemGiB,
+	memFormula: memFormula
+}

--- a/workflow/src/mem-formula.lib.tengo
+++ b/workflow/src/mem-formula.lib.tengo
@@ -1,11 +1,12 @@
 // Single source of truth for the `mixcr analyze` memory request.
 //
-// The floor is a TOTAL-memory value for the analysis, chosen by which steps the
-// preset runs. size("reads") is the stored (compressed) blob size of the sample's
-// FASTQs — metadata only, no pre-exec pass — so the formula resolves on backends
-// that expose blob size, and falls back to the bare floor on those that do not.
+//     mem = clamp(4 x size("reads"), baseMemGiB, 256 GiB)
 //
-//     mem = clamp(4 bytes/byte x size, baseMemGiB, 256 GiB)
+// baseMemGiB is a TOTAL-memory value for the analysis, selected by which steps the
+// preset runs, so it acts as the lower bound rather than a base to add data on top of.
+// size("reads") is the stored (compressed) blob size of the sample's FASTQs, read from
+// metadata with no pre-exec pass, so the formula resolves on backends that expose blob
+// size and falls back to the bare floor on those that do not.
 
 exec := import("@platforma-sdk/workflow-tengo:exec")
 

--- a/workflow/src/mem-formula.lib.tengo
+++ b/workflow/src/mem-formula.lib.tengo
@@ -5,7 +5,7 @@
 // FASTQs — metadata only, no pre-exec pass — so the formula resolves on backends
 // that expose blob size, and falls back to the bare floor on those that do not.
 //
-//     mem = clamp(baseMemGiB + 4 bytes/byte x size, baseMemGiB, 256 GiB)
+//     mem = clamp(4 bytes/byte x size, baseMemGiB, 256 GiB)
 
 exec := import("@platforma-sdk/workflow-tengo:exec")
 
@@ -24,9 +24,9 @@ baseMemGiB := func(hasMiToolSteps, hasAssembleContigs, hasAssembleCells) {
 }
 
 // memFormula builds the fluent exec.formula node for `.resources({onCPU:{ram}})`.
+// between() supplies `base` as the lower bound, so no explicit max() is needed.
 memFormula := func(base) {
-	return f.gib(base).
-		plus(f.size("reads").times(4)).
+	return f.size("reads").times(4).
 		between(f.gib(base), f.gib(256)).
 		staticFallback(f.gib(base))
 }

--- a/workflow/src/mem-formula.test.tengo
+++ b/workflow/src/mem-formula.test.tengo
@@ -30,25 +30,26 @@ TestBaseMemGiBSelection := func() {
 	test.isEqual(192, mf.baseMemGiB(true, true, true))
 }
 
-TestMemFormulaToday := func() {
-	// CHARACTERIZATION: locks in today's additive behaviour,
-	//   mem = clamp(base + 4 x size, base, 256 GiB)
-	// Task 2 changes these numbers deliberately. The diff is the ledger.
+TestMemFormula := func() {
+	// mem = clamp(4 x size, base, 256 GiB) — the floor is a TOTAL, not a base to add to.
 
-	// Reference input: 110 GiB floor + 127 GiB data term = 237 GiB.
-	test.isEqual(_gib(237), _eval(mf.memFormula(110), _READS_31_75_GIB))
+	// Reference input: 4 x 31.75 GiB = 127 GiB, above the 110 GiB floor.
+	// Was 237 GiB before the double-count was removed.
+	test.isEqual(_gib(127), _eval(mf.memFormula(110), _READS_31_75_GIB))
 
-	// Empty input still pays the full floor.
+	// Empty input falls to the floor, unchanged.
 	test.isEqual(_gib(64),  _eval(mf.memFormula(64),  0))
 	test.isEqual(_gib(110), _eval(mf.memFormula(110), 0))
 	test.isEqual(_gib(192), _eval(mf.memFormula(192), 0))
 
-	// 32 GiB of reads: the data term is 128 GiB and is ADDED to the floor.
-	test.isEqual(_gib(192), _eval(mf.memFormula(64),  _gib(32)))
-	test.isEqual(_gib(238), _eval(mf.memFormula(110), _gib(32)))
-	// 192 + 128 = 320, clamped down to the 256 GiB ceiling.
-	test.isEqual(_gib(256), _eval(mf.memFormula(192), _gib(32)))
+	// 32 GiB of reads: the data term is 128 GiB and now STANDS ALONE.
+	test.isEqual(_gib(128), _eval(mf.memFormula(64),  _gib(32)))  // was 192
+	test.isEqual(_gib(128), _eval(mf.memFormula(110), _gib(32)))  // was 238
+	test.isEqual(_gib(192), _eval(mf.memFormula(192), _gib(32)))  // was 256 — floor now binds
 
-	// The static fallback is the floor, for backends without blob-size metadata.
+	// The ceiling still binds: 4 x 96 GiB = 384 GiB, clamped to 256.
+	test.isEqual(_gib(256), _eval(mf.memFormula(64), _gib(96)))
+
+	// The static fallback is unchanged.
 	test.isEqual(_gib(110), f.fallbackOf(mf.memFormula(110)))
 }

--- a/workflow/src/mem-formula.test.tengo
+++ b/workflow/src/mem-formula.test.tengo
@@ -1,0 +1,54 @@
+test := import("@platforma-sdk/workflow-tengo:test")
+exec := import("@platforma-sdk/workflow-tengo:exec")
+mf := import(":mem-formula")
+
+f := exec.formula
+
+_gib := func(n) { return n * 1073741824 }
+
+// Evaluate a resource formula against a fake "reads" input of sizeBytes.
+_eval := func(node, sizeBytes) {
+	fileName := "input.fastq.gz"
+	resolved := f.resolveAst(node, { "reads": [fileName] }, [fileName])
+	resolver := {
+		size:      func(files) { return sizeBytes },
+		lineCount: func(files) { return 0 }
+	}
+	return f.evaluateResource(resolved, resolver, "test")
+}
+
+// A large real input: the assemble-contigs floor (110 GiB) with 31.75 GiB of
+// reads, so the data term 4 x size is exactly 127 GiB.
+_READS_31_75_GIB := 34091302912
+
+TestBaseMemGiBSelection := func() {
+	test.isEqual(64,  mf.baseMemGiB(false, false, false))
+	test.isEqual(110, mf.baseMemGiB(false, true, false))
+	test.isEqual(110, mf.baseMemGiB(false, false, true))
+	test.isEqual(192, mf.baseMemGiB(true, false, false))
+	// mitool steps win over contigs/cells
+	test.isEqual(192, mf.baseMemGiB(true, true, true))
+}
+
+TestMemFormulaToday := func() {
+	// CHARACTERIZATION: locks in today's additive behaviour,
+	//   mem = clamp(base + 4 x size, base, 256 GiB)
+	// Task 2 changes these numbers deliberately. The diff is the ledger.
+
+	// Reference input: 110 GiB floor + 127 GiB data term = 237 GiB.
+	test.isEqual(_gib(237), _eval(mf.memFormula(110), _READS_31_75_GIB))
+
+	// Empty input still pays the full floor.
+	test.isEqual(_gib(64),  _eval(mf.memFormula(64),  0))
+	test.isEqual(_gib(110), _eval(mf.memFormula(110), 0))
+	test.isEqual(_gib(192), _eval(mf.memFormula(192), 0))
+
+	// 32 GiB of reads: the data term is 128 GiB and is ADDED to the floor.
+	test.isEqual(_gib(192), _eval(mf.memFormula(64),  _gib(32)))
+	test.isEqual(_gib(238), _eval(mf.memFormula(110), _gib(32)))
+	// 192 + 128 = 320, clamped down to the 256 GiB ceiling.
+	test.isEqual(_gib(256), _eval(mf.memFormula(192), _gib(32)))
+
+	// The static fallback is the floor, for backends without blob-size metadata.
+	test.isEqual(_gib(110), f.fallbackOf(mf.memFormula(110)))
+}

--- a/workflow/src/mem-formula.test.tengo
+++ b/workflow/src/mem-formula.test.tengo
@@ -31,25 +31,23 @@ TestBaseMemGiBSelection := func() {
 }
 
 TestMemFormula := func() {
-	// mem = clamp(4 x size, base, 256 GiB) — the floor is a TOTAL, not a base to add to.
+	// mem = clamp(4 x size, base, 256 GiB). base is the lower bound, not a base to add to.
 
 	// Reference input: 4 x 31.75 GiB = 127 GiB, above the 110 GiB floor.
-	// Was 237 GiB before the double-count was removed.
 	test.isEqual(_gib(127), _eval(mf.memFormula(110), _READS_31_75_GIB))
 
-	// Empty input falls to the floor, unchanged.
+	// Empty input falls to the floor.
 	test.isEqual(_gib(64),  _eval(mf.memFormula(64),  0))
 	test.isEqual(_gib(110), _eval(mf.memFormula(110), 0))
 	test.isEqual(_gib(192), _eval(mf.memFormula(192), 0))
 
-	// 32 GiB of reads: the data term is 128 GiB and now STANDS ALONE.
-	test.isEqual(_gib(128), _eval(mf.memFormula(64),  _gib(32)))  // was 192
-	test.isEqual(_gib(128), _eval(mf.memFormula(110), _gib(32)))  // was 238
-	test.isEqual(_gib(192), _eval(mf.memFormula(192), _gib(32)))  // was 256 — floor now binds
+	// 32 GiB of reads: the data term is 128 GiB and stands alone.
+	test.isEqual(_gib(128), _eval(mf.memFormula(64),  _gib(32)))
+	test.isEqual(_gib(128), _eval(mf.memFormula(110), _gib(32)))
+	test.isEqual(_gib(192), _eval(mf.memFormula(192), _gib(32)))  // floor binds
 
-	// The ceiling still binds: 4 x 96 GiB = 384 GiB, clamped to 256.
+	// The ceiling binds: 4 x 96 GiB = 384 GiB, clamped to 256.
 	test.isEqual(_gib(256), _eval(mf.memFormula(64), _gib(96)))
 
-	// The static fallback is unchanged.
 	test.isEqual(_gib(110), f.fallbackOf(mf.memFormula(110)))
 }

--- a/workflow/src/mixcr-analyze.tpl.tengo
+++ b/workflow/src/mixcr-analyze.tpl.tengo
@@ -1,4 +1,4 @@
-//tengo:hash_override D70EDB25-6FF6-4615-966D-B79B04B5751C
+//tengo:hash_override AD2092AB-97D5-4758-873E-EEB932A856EA
 
 self := import("@platforma-sdk/workflow-tengo:tpl")
 smart := import("@platforma-sdk/workflow-tengo:smart")
@@ -84,14 +84,16 @@ self.body(func(inputs) {
 	perProcessCPUsResolved := is_undefined(perProcessCPUs) ? 16 : perProcessCPUs
 
 	// Memory limit per process.
-	// Size analyze RAM from the input reads' file size, on top of a per-analysis
-	// floor. size("reads") sums the stored (compressed) blob size of the sample's
-	// R1+R2 FASTQ via getBlobSize — a metadata read, no pre-exec — so it tracks
-	// total input volume (read count and read length) without decompressing.
-	//     mem = clamp(baseMemGiB + 4 bytes/byte * size, baseMemGiB, 256 GiB)
-	// baseMemGiB is the per-analysis floor (64, or 110/192 for contig/cell and
-	// single-cell+MiTool pipelines, which need that headroom regardless of size);
-	// the linear term scales with input volume; the 256 GiB cap bounds the largest.
+	// Size analyze RAM from the input reads' file size. size("reads") sums the
+	// stored (compressed) blob size of the sample's R1+R2 FASTQ via getBlobSize —
+	// a metadata read, no pre-exec — so it tracks total input volume (read count
+	// and read length) without decompressing.
+	//     mem = clamp(4 bytes/byte * size, baseMemGiB, 256 GiB)
+	// baseMemGiB is a TOTAL-memory floor for the analysis, not a base to add data on
+	// top of — adding a data term to it double-counted the input. The floor is 64, or
+	// 110/192 for contig/cell and single-cell+MiTool pipelines, which need that
+	// headroom regardless of input size; the linear term scales with input volume;
+	// the 256 GiB cap bounds the largest.
 	// An "Advanced Settings" memory override takes precedence; on backends that
 	// cannot evaluate resource formulas, the formula's static fallback is the baseline.
     if !is_undefined(perProcessMemGB) {

--- a/workflow/src/mixcr-analyze.tpl.tengo
+++ b/workflow/src/mixcr-analyze.tpl.tengo
@@ -10,6 +10,7 @@ pcolumn := import("@platforma-sdk/workflow-tengo:pframes.pcolumn")
 times := import("times")
 text := import("text")
 maps := import("@platforma-sdk/workflow-tengo:maps")
+memf := import(":mem-formula")
 
 json := import("json")
 
@@ -97,19 +98,10 @@ self.body(func(inputs) {
         // memory per process was set in "Advanced Settings" block directly
 		mixcrCmdBuilder.cpu(perProcessCPUsResolved).mem(string(perProcessMemGB) + "GiB")
 	} else {
-		baseMemGiB := 64
-		if hasMiToolSteps {
-			baseMemGiB = 192
-		} else if hasAssembleContigs || hasAssembleCells {
-			baseMemGiB = 110
-		}
-		// workflow-tengo 6.7 fluent formula API fed via .resources({ onCPU: { cpu, ram } }).
-		formula := exec.formula
-		memFormula := formula.gib(baseMemGiB).
-			plus(formula.size("reads").times(4)).
-			between(formula.gib(baseMemGiB), formula.gib(256)).
-			staticFallback(formula.gib(baseMemGiB))
-		mixcrCmdBuilder.resources({ onCPU: { cpu: perProcessCPUsResolved, ram: memFormula } })
+		base := memf.baseMemGiB(hasMiToolSteps, hasAssembleContigs, hasAssembleCells)
+		mixcrCmdBuilder.resources({
+			onCPU: { cpu: perProcessCPUsResolved, ram: memf.memFormula(base) }
+		})
 	}
 
 	if !is_undefined(limitInput) {

--- a/workflow/src/mixcr-analyze.tpl.tengo
+++ b/workflow/src/mixcr-analyze.tpl.tengo
@@ -84,18 +84,17 @@ self.body(func(inputs) {
 	perProcessCPUsResolved := is_undefined(perProcessCPUs) ? 16 : perProcessCPUs
 
 	// Memory limit per process.
-	// Size analyze RAM from the input reads' file size. size("reads") sums the
-	// stored (compressed) blob size of the sample's R1+R2 FASTQ via getBlobSize —
-	// a metadata read, no pre-exec — so it tracks total input volume (read count
-	// and read length) without decompressing.
-	//     mem = clamp(4 bytes/byte * size, baseMemGiB, 256 GiB)
-	// baseMemGiB is a TOTAL-memory floor for the analysis, not a base to add data on
-	// top of — adding a data term to it double-counted the input. The floor is 64, or
-	// 110/192 for contig/cell and single-cell+MiTool pipelines, which need that
-	// headroom regardless of input size; the linear term scales with input volume;
-	// the 256 GiB cap bounds the largest.
-	// An "Advanced Settings" memory override takes precedence; on backends that
-	// cannot evaluate resource formulas, the formula's static fallback is the baseline.
+	//     mem = clamp(4 * size("reads"), baseMemGiB, 256 GiB)
+	// size("reads") sums the stored (compressed) blob size of the sample's R1+R2 FASTQ
+	// via getBlobSize — a metadata read, no pre-exec — so it tracks total input volume
+	// (read count and read length) without decompressing.
+	// baseMemGiB is a TOTAL-memory floor for the analysis, so it acts as the lower bound
+	// rather than a base to add data on top of. It is 64 GiB, rising to 110 or 192 for
+	// contig/cell and single-cell+MiTool pipelines, which need that headroom whatever the
+	// input size. The linear term scales with input volume, and the 256 GiB cap bounds
+	// the largest runs.
+	// An "Advanced Settings" memory override takes precedence. On backends that cannot
+	// evaluate resource formulas, the formula's static fallback is the baseline.
     if !is_undefined(perProcessMemGB) {
         // memory per process was set in "Advanced Settings" block directly
 		mixcrCmdBuilder.cpu(perProcessCPUsResolved).mem(string(perProcessMemGB) + "GiB")


### PR DESCRIPTION
## What

The analyze memory request counted the input size twice. `baseMemGiB` — 64 GiB, or 110/192 for contig/cell and MiTool presets — is a **total**-memory value for the whole analysis, but the formula added a data term on top of it:

```
before:  mem = clamp(baseMemGiB + 4 x size("reads"), baseMemGiB, 256 GiB)
after:   mem = clamp(4 x size("reads"),              baseMemGiB, 256 GiB)
```

No `max()` is needed in its place: `.between(base, 256)` already supplies `base` as the lower bound. That bound was dead code until now, because an additive term can never fall below the floor it was added to.

## Effect

| reads | floor | before | after |
|---|---|---|---|
| 31.75 GiB | 110 GiB | 237 GiB | **127 GiB** |
| 32 GiB | 64 GiB | 192 GiB | **128 GiB** |
| empty | 110 GiB | 110 GiB | 110 GiB |
| 96 GiB | 64 GiB | 256 GiB (cap) | 256 GiB (cap) |

Large samples request materially less. Small samples are unchanged — they were floor-bound before and stay floor-bound. Lowering the floors themselves is deliberately out of scope; that needs separate agreement on whether 64/110/192 can safely come down.

The 256 GiB ceiling is untouched, as is the "Advanced Settings" memory override, which takes a separate `perProcessMemGB` branch this change never reaches.

## Structure

Two commits, kept separate on purpose:

1. **Extract** the arithmetic into `mem-formula.lib.tengo` behind a characterization test pinning today's values. Computes identical results.
2. **Flip** the behaviour. This commit's test diff is the whole record of what moved — read it alone and you see 237 become 127.

The formula previously sat inside `self.body(func(inputs) {...})` where no test could reach it. The extraction is the seam that makes it assertable.

## hash_override UUID bump

`mixcr-analyze.tpl.tengo` carries a pinned `//tengo:hash_override`, bumped here to a fresh UUID. This forces a one-time recompute of results cached against the old hash.

The previous value was shared byte-for-byte with `mixcr-amplicon-alignment`, whose body differs substantially — and two templates pinning one UUID are interchangeable as far as the backend is concerned. Both now pin distinct fresh values; see the companion PR in that repo.

## Testing

`pnpm exec pl-tengo test` passes `TestBaseMemGiBSelection` and `TestMemFormula`. Each was confirmed failing before its fix, so neither is vacuous — the flip commit's test failed with `expect: 136365211648, got 254476812288` until the lib changed. `pnpm run build:dev-no-software` and `pnpm exec pl-tengo check` are clean; the compiled lib carries no `plus` and the compiled template carries the new UUID.

**No live run yet** — this is unit- and build-level verification only. A meaningful live check needs an input the backend has never computed, or a previously-failed one. Memory and CPU go into `metaExtra` and are excluded from a resource's canonical ID, specifically so dedup reuses results across differing grants, so re-running an already-successful sample cannot surface a new grant however correct the change is.

Two pre-existing issues in this repo, neither introduced here and both out of scope:

- `pnpm run test` is unusable as a gate — it chains a vitest suite needing a live backend, which fails with `ECONNREFUSED 127.0.0.1:6345`.
- `pnpm exec changeset status` fails on `yaml.safeLoad is removed in js-yaml 4` from `read-yaml-file@1.1.0`, reproducible with this branch's changeset removed. The changeset was validated with the repo's own `@changesets/parse` instead.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts and corrects the MiXCR analyze memory formula so input size is counted once while preserving preset floors, the 256 GiB ceiling, and explicit memory overrides. It also changes the analyze template hash to invalidate cached results and adds characterization coverage.
- **`baseMemGiB`**: The total-memory floor selected from pipeline steps—64 GiB normally, 110 GiB for contig/cell assembly, and 192 GiB for MiTool. It is extracted into `mem-formula.lib.tengo` and used as the clamp’s lower bound instead of an additive term.
- **`memFormula`**: The resource formula used to request analyze RAM. It changes from `clamp(base + 4 × reads size, base, 256 GiB)` to `clamp(4 × reads size, base, 256 GiB)`.
- **`size("reads")`**: The stored compressed size of FASTQ inputs tagged as reads. It remains multiplied by four but is no longer combined additively with the memory floor.
- **`staticFallback`**: The memory used when the backend cannot evaluate the dynamic formula. It remains the selected `baseMemGiB`.
- **`perProcessMemGB`**: The Advanced Settings memory override. Its separate branch remains unchanged and bypasses the formula.
- **`hash_override`**: The analyze template’s pinned cache identity. It receives a new UUID to force one-time recomputation rather than reusing results associated with the previous formula.
- **Tengo test target**: The workflow package’s `test` script now runs `pl-tengo test` before Vitest, covering the extracted floor selection and memory arithmetic.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| workflow/src/mem-formula.lib.tengo | Extracts preset floor selection and implements the non-additive, bounded analyze memory formula with the original static fallback. |
| workflow/src/mem-formula.test.tengo | Covers all floor-selection branches, representative input sizes, ceiling behavior, and the static fallback. |
| workflow/src/mixcr-analyze.tpl.tengo | Delegates analyze memory sizing to the extracted library and changes the template hash while preserving the explicit override path. |
| workflow/package.json | Adds Tengo unit tests to the workflow package’s standard test command. |
| .changeset/analyze-mem-no-double-count.md | Documents the corrected formula, expected resource reductions, preserved bounds and override, and cache recomputation. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Analyze request] --> B{perProcessMemGB defined?}
    B -- Yes --> C[Use explicit GiB override]
    B -- No --> D[Inspect preset pipeline steps]
    D --> E[Select floor: 64, 110, or 192 GiB]
    E --> F[Compute 4 × stored reads size]
    F --> G[Clamp between selected floor and 256 GiB]
    G --> H[Submit CPU and RAM resources]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["MILAB-6721: clarify memory formula comme..."](https://github.com/platforma-open/mixcr-clonotyping/commit/dfc7fc7833ce724dce748523960a35c92a20dac7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50049270)</sub>

<!-- /greptile_comment -->