### PR TITLE
MILAB-6648: add the mandatory block kind and migrate column access

### DIFF
--- a/.changeset/mixcr-clonotyping-block-kind.md
+++ b/.changeset/mixcr-clonotyping-block-kind.md
@@ -1,0 +1,20 @@
+---
+'@platforma-open/milaboratories.mixcr-clonotyping-2.kind': minor
+'@platforma-open/milaboratories.mixcr-clonotyping-2.model': minor
+'@platforma-open/milaboratories.mixcr-clonotyping-2': minor
+---
+
+Add the mandatory block kind and migrate the model to the new column access API
+
+The block now declares a `kind/` package carrying its identity and its
+init-params contract — the fields a project template supplies to seed a new
+instance. The model consumes them in `init` and projects the same set back out
+via `templateParams`, so export and apply are inverses. File-valued params are
+narrowed to `index://` handles, since an `upload://` handle names an import
+local to one machine and would not resolve after a template is applied
+elsewhere.
+
+Model column access moves off the removed/deprecated surface: `ColumnLazy` →
+`DataColumn`, `resultPool.getSpecByRef` → `Column(ref).getSpec()`, and all three
+`getPColumns()` call sites → `ColumnsCollection`, which resolves ids host-side
+instead of materialising specs and data in the sandbox.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,6 +39,11 @@ jobs:
       package-path: 'block'
       create-tag: 'true'
 
+      # Require the published `block` package to be bumped by a changeset on
+      # PRs (empty changeset or the `skip-changelog` label waives it). Needs
+      # the input to exist on the pinned `@v4` reusable workflow.
+      require-package-path-bump: true
+
       npmrc-config: |
         {
           "registries": {

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
     with:
       app-name: 'Block: Mixcr Clonotyping 2'
       app-name-slug: 'block-mixcr-clonotyping-2'
-      node-version: '20.x'
+      node-version: '22.x'
       gha-runner-label: hz-ubuntu-dind
       build-script-name: 'build:dev-local'
       build-before-publish-script-name: 'build:release'

--- a/.github/workflows/mark-stable.yaml
+++ b/.github/workflows/mark-stable.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: milaboratory/github-ci/.github/workflows/block-mark-stable.yaml@v4
     with:
       app-name: 'Block: Mixcr Clonotyping 2 - Mark Stable'
-      node-version: '20.x'
+      node-version: '22.x'
       npmrc-config: |
         {
           "registries": {

--- a/block/package.json
+++ b/block/package.json
@@ -11,14 +11,15 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "sources": "./src/index.ts",
       "types": "./dist/index.d.ts",
+      "sources": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },
   "scripts": {
     "build": "ts-builder build --target block-facade && block-tools pack",
-    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1 --registry-serve-url https://blocks.pl-open.science",
+    "prepublishOnly": "block-tools publish --unstable -r s3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1 --registry-serve-url https://blocks.pl-open.science",
+    "mark-stable": "block-tools mark-stable -r 's3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1'",
     "do-pack": "shx rm -f package.tgz && pnpm pack && shx mv *.tgz package.tgz",
     "check": "ts-builder type-check --target block-facade"
   },

--- a/block/package.json
+++ b/block/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "ts-builder build --target block-facade && block-tools pack",
-    "prepublishOnly": "block-tools publish --unstable -r s3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1 --registry-serve-url https://blocks.pl-open.science",
+    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1 --registry-serve-url https://blocks.pl-open.science",
     "mark-stable": "block-tools mark-stable -r 's3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1'",
     "do-pack": "shx rm -f package.tgz && pnpm pack && shx mv *.tgz package.tgz",
     "check": "ts-builder type-check --target block-facade"

--- a/block/package.json
+++ b/block/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@milaboratories/ts-builder": "catalog:",
     "@milaboratories/ts-configs": "catalog:",
+    "@platforma-open/milaboratories.mixcr-clonotyping-2.kind": "workspace:*",
     "@platforma-open/milaboratories.mixcr-clonotyping-2.model": "workspace:*",
     "@platforma-open/milaboratories.mixcr-clonotyping-2.ui": "workspace:*",
     "@platforma-open/milaboratories.mixcr-clonotyping-2.workflow": "workspace:*",

--- a/kind/.oxfmtrc.json
+++ b/kind/.oxfmtrc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["node_modules/@milaboratories/ts-builder/configs/oxfmt.json"],
+  "ignorePatterns": ["dist", "coverage", "CHANGELOG.md"]
+}

--- a/kind/.oxlintrc.json
+++ b/kind/.oxlintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["node_modules/@milaboratories/ts-builder/dist/configs/oxlint-node.json"]
+}

--- a/kind/package.json
+++ b/kind/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@platforma-open/milaboratories.mixcr-clonotyping-2.kind",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Block kind for the mixcr-clonotyping block",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "sources": "./src/index.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "fmt": "ts-builder format",
+    "watch": "ts-builder build --target block-kind --watch",
+    "build": "ts-builder build --target block-kind && block-tools build-kind-manifest",
+    "check": "ts-builder check --target block-kind"
+  },
+  "dependencies": {
+    "@platforma-sdk/block-kind": "catalog:",
+    "@platforma-sdk/model": "catalog:",
+    "es-toolkit": "catalog:"
+  },
+  "devDependencies": {
+    "@milaboratories/ts-builder": "catalog:",
+    "@milaboratories/ts-configs": "catalog:",
+    "@platforma-sdk/block-tools": "catalog:"
+  },
+  "peerDependencies": {
+    "@types/node": "*",
+    "typescript": "*"
+  }
+}

--- a/kind/src/index.ts
+++ b/kind/src/index.ts
@@ -1,0 +1,22 @@
+import { defineBlockKind } from "@platforma-sdk/block-kind";
+import { name, version } from "../package.json" with { type: "json" };
+import { parseInitializationParams } from "./params";
+import type { BlockParams } from "./types";
+
+export type {
+  BlockParams,
+  CloneClusteringMode,
+  Preset,
+  RunMode,
+  StopCodonReplacements,
+  StopCodonType,
+} from "./types";
+
+// Identity (`name`/`version`) comes from this package's own `package.json`, so
+// the on-wire `{name}@{version}` reference can never drift from what npm
+// publishes; the bundler inlines the JSON import.
+export const kind = defineBlockKind<BlockParams>({
+  name,
+  version,
+  parseInitializationParams,
+});

--- a/kind/src/params.ts
+++ b/kind/src/params.ts
@@ -1,0 +1,136 @@
+import { assertParamsObject } from "@platforma-sdk/block-kind";
+import {
+  isImportFileHandleIndex,
+  isPlRef,
+  type ImportFileHandle,
+  type ImportFileHandleIndex,
+} from "@platforma-sdk/model";
+import { isBoolean, isPlainObject, isString } from "es-toolkit";
+import type {
+  BlockParams,
+  CloneClusteringMode,
+  Preset,
+  RunMode,
+  StopCodonReplacements,
+  StopCodonType,
+} from "./types";
+
+/**
+ * The contract at runtime, for params that arrive from a template file rather
+ * than from typed code.
+ *
+ * Each field the contract names is read and checked; a key it does not name is
+ * dropped by never being read, so it needs no rejection here. Params written
+ * against a different version of the contract are caught by the version in the
+ * template entry's `{name}@{selector}` reference, not by a key-set check.
+ */
+export function parseInitializationParams(value: unknown): BlockParams {
+  assertParamsObject(value);
+
+  const params: Record<string, unknown> = {};
+  for (const [field, { is, must }] of Object.entries(CONTRACT)) {
+    const raw = value[field];
+    if (raw === undefined) continue;
+    if (!is(raw)) throw new Error(`'${field}' must be ${must}.`);
+    params[field] = raw;
+  }
+  // Every value placed here passed its own field's guard, and `CONTRACT` is
+  // proven exhaustive over `BlockParams` by the `satisfies` below.
+  return params as BlockParams;
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+type Guard<T> = (value: unknown) => value is T;
+
+/** A guard plus how to finish the sentence "'field' must be …". */
+type Check<T> = { readonly is: Guard<T>; readonly must: string };
+
+function check<T>(is: Guard<T>, must: string): Check<T> {
+  return { is, must };
+}
+
+/** `Number.isInteger` already rejects non-numbers; this only adds the narrowing. */
+const isInteger: Guard<number> = (v): v is number => Number.isInteger(v);
+
+function oneOf<T extends string>(...allowed: readonly T[]): Guard<T> {
+  return (v): v is T => allowed.includes(v as T);
+}
+
+function arrayOf<T>(item: Guard<T>): Guard<T[]> {
+  return (v): v is T[] => Array.isArray(v) && v.every((e) => item(e));
+}
+
+/**
+ * `isImportFileHandleIndex` is a prefix test, so handing it a checked string is
+ * safe; the cast only gets the string past a signature that expects the union.
+ */
+const isIndexFileHandle: Guard<ImportFileHandleIndex> = (v): v is ImportFileHandleIndex =>
+  isString(v) && isImportFileHandleIndex(v as ImportFileHandle);
+
+const STOP_CODON_TYPES = ["amber", "ochre", "opal"] as const;
+
+const isPreset: Guard<Preset> = (v): v is Preset =>
+  isPlainObject(v) &&
+  (v.type === "name" ? isString(v.name) : v.type === "file" && isIndexFileHandle(v.file));
+
+const isStopCodonReplacements: Guard<StopCodonReplacements> = (v): v is StopCodonReplacements =>
+  isPlainObject(v) && STOP_CODON_TYPES.every((k) => v[k] === undefined || isString(v[k]));
+
+const REF = "a reference to another block's output";
+const INDEX_HANDLE =
+  "an 'index://' file handle — an 'upload://' handle names a local import and does not resolve on another machine";
+
+/**
+ * The contract, field by field, at runtime.
+ *
+ * The `satisfies` clause is the drift guard: it demands an entry for every key
+ * `BlockParams` declares, and types each guard against that key's own type. Add
+ * a field to the contract and this stops compiling until the check exists —
+ * which matters here because every field is optional, so a parser that simply
+ * forgot one would otherwise return a valid `BlockParams` and say nothing.
+ */
+const CONTRACT = {
+  input: check(isPlRef, REF),
+  inputLibrary: check(isPlRef, REF),
+  libraryFile: check(isIndexFileHandle, INDEX_HANDLE),
+  isLibraryFileGzipped: check(isBoolean, "a boolean"),
+
+  preset: check(isPreset, "{ type: 'name', name } or { type: 'file', file }"),
+  presetCommonName: check(isString, "a string"),
+  isGenericPreset: check(isBoolean, "a boolean"),
+  species: check(isString, "a string"),
+  customSpecies: check(isString, "a string"),
+  materialType: check(isString, "a string"),
+  leftAlignmentMode: check(isString, "a string"),
+  rightAlignmentMode: check(isString, "a string"),
+  tagPattern: check(isString, "a string"),
+  assembleClonesBy: check(isString, "a string"),
+  imputeGermline: check(isBoolean, "a boolean"),
+  chains: check(arrayOf(isString), "an array of strings"),
+  scHeavyOnly: check(isBoolean, "a boolean"),
+  cloneClusteringMode: check(
+    oneOf<CloneClusteringMode>("relaxed", "default", "off"),
+    "one of: relaxed, default, off",
+  ),
+  exportMinQuality: check(isBoolean, "a boolean"),
+  stopCodonTypes: check(
+    arrayOf(oneOf<StopCodonType>(...STOP_CODON_TYPES)),
+    "an array of: amber, ochre, opal",
+  ),
+  stopCodonReplacements: check(
+    isStopCodonReplacements,
+    "an object of optional amber / ochre / opal strings",
+  ),
+
+  runMode: check(oneOf<RunMode>("dry", "full"), "one of: dry, full"),
+  limitInput: check(isInteger, "an integer"),
+  perProcessMemGB: check(isInteger, "an integer"),
+  perProcessCPUs: check(isInteger, "an integer"),
+
+  defaultBlockLabel: check(isString, "a string"),
+  customBlockLabel: check(isString, "a string"),
+  title: check(isString, "a string"),
+} satisfies { [K in keyof BlockParams]-?: Check<NonNullable<BlockParams[K]>> };

--- a/kind/src/types.ts
+++ b/kind/src/types.ts
@@ -1,0 +1,70 @@
+import type { ImportFileHandleIndex, PlRef } from "@platforma-sdk/model";
+
+/** MiXCR preset — either a named built-in or a preset file. */
+export type Preset = { type: "name"; name: string } | { type: "file"; file: ImportFileHandleIndex };
+
+export type StopCodonType = "amber" | "ochre" | "opal";
+
+export type StopCodonReplacements = {
+  amber?: string;
+  ochre?: string;
+  opal?: string;
+};
+
+export type CloneClusteringMode = "relaxed" | "default" | "off";
+
+/** Preview runs a read-limited pass; full runs the whole dataset. */
+export type RunMode = "dry" | "full";
+
+/**
+ * This block's init-params contract — the shape a block of this kind receives
+ * at creation, and exactly what a project template serializes for it.
+ *
+ * Every field is optional. A block with no input picked and no preset chosen is
+ * an ordinary state the UI reaches, so export has to be able to write it and
+ * apply has to be able to take it back; a contract that demanded `input` would
+ * make export and apply stop being inverses. Whether a configuration is
+ * runnable is settled by the model's `args` lambda, not here.
+ *
+ * File-valued fields are narrowed to `index://` handles. An `upload://` handle
+ * names an import local to one machine, so it cannot survive being written to a
+ * template and applied elsewhere; the projection drops those rather than
+ * writing a reference that resolves nowhere.
+ */
+export type BlockParams = {
+  // Input wiring — PlRefs a template engine fills from an earlier entry's output.
+  input?: PlRef;
+  inputLibrary?: PlRef;
+  libraryFile?: ImportFileHandleIndex;
+  isLibraryFileGzipped?: boolean;
+
+  // Analysis configuration — the recipe a template exists to reproduce.
+  preset?: Preset;
+  presetCommonName?: string;
+  isGenericPreset?: boolean;
+  species?: string;
+  customSpecies?: string;
+  materialType?: string;
+  leftAlignmentMode?: string;
+  rightAlignmentMode?: string;
+  tagPattern?: string;
+  assembleClonesBy?: string;
+  imputeGermline?: boolean;
+  chains?: string[];
+  scHeavyOnly?: boolean;
+  cloneClusteringMode?: CloneClusteringMode;
+  exportMinQuality?: boolean;
+  stopCodonTypes?: StopCodonType[];
+  stopCodonReplacements?: StopCodonReplacements;
+
+  // Run mode and per-process resource limits.
+  runMode?: RunMode;
+  limitInput?: number;
+  perProcessMemGB?: number;
+  perProcessCPUs?: number;
+
+  // Display naming.
+  defaultBlockLabel?: string;
+  customBlockLabel?: string;
+  title?: string;
+};

--- a/kind/tsconfig.json
+++ b/kind/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@milaboratories/ts-configs/block/facade",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*", "package.json"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/model/package.json
+++ b/model/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@milaboratories/helpers": "catalog:",
+    "@platforma-open/milaboratories.mixcr-clonotyping-2.kind": "workspace:*",
     "@platforma-sdk/model": "catalog:",
     "zod": "catalog:"
   },

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -1,15 +1,23 @@
 import type { InferHrefType, PlDataTableStateV2 } from "@platforma-sdk/model";
 import {
   BlockModelV3,
-  ColumnLazy,
+  Column,
+  ColumnsCollection,
+  TreeNodeAccessor,
   DataModelBuilder,
   createPlDataTableStateV2,
   createPlDataTableV3,
+  isDataColumn,
+  isImportFileHandleIndex,
   isPColumnSpec,
   parseResourceMap,
+  type ColumnData,
   type ImportFileHandle,
+  type ImportFileHandleIndex,
   type InferOutputsType,
 } from "@platforma-sdk/model";
+import type { BlockParams as KindBlockParams } from "@platforma-open/milaboratories.mixcr-clonotyping-2.kind";
+import { kind } from "@platforma-open/milaboratories.mixcr-clonotyping-2.kind";
 import type { BlockArgs } from "./args";
 import { BlockArgsValid } from "./args";
 import { ProgressPrefix } from "./progress";
@@ -23,23 +31,64 @@ type LegacyUiState = {
   tableState: PlDataTableStateV2;
 };
 
-const dataModel = new DataModelBuilder()
+const dataModel = new DataModelBuilder({ kind })
   .from<BlockData>("v1")
   .upgradeLegacy<BlockArgs, LegacyUiState>(({ args, uiState }) => ({
     ...args,
     tableState: uiState.tableState,
     runMode: (args.limitInput ?? 0) > 0 ? "dry" : "full",
   }))
-  .init(() => ({
-    defaultBlockLabel: "",
-    customBlockLabel: "",
-    chains: ["IG", "TCRAB", "TCRGD"],
-    cloneClusteringMode: "default",
+  // `params` is absent when a block is created by hand rather than from a
+  // template, so every field the contract carries keeps its own default.
+  .init(({ params }) => ({
+    ...params,
+    defaultBlockLabel: params?.defaultBlockLabel ?? "",
+    customBlockLabel: params?.customBlockLabel ?? "",
+    chains: params?.chains ?? ["IG", "TCRAB", "TCRGD"],
+    cloneClusteringMode: params?.cloneClusteringMode ?? "default",
     tableState: createPlDataTableStateV2(),
-    runMode: "full",
+    runMode: params?.runMode ?? "full",
   }));
 
-export const platforma = BlockModelV3.create(dataModel)
+export const platforma = BlockModelV3.create({ dataModel, kind })
+
+  // Inverse of `init` — the same fields, projected back out for template export.
+  // `tableState` is view state and never crosses the boundary. File-valued
+  // fields are dropped unless they are `index://` handles: an `upload://` handle
+  // names an import local to this machine and would resolve nowhere else.
+  .templateParams((data) => ({
+    input: data.input,
+    inputLibrary: data.inputLibrary,
+    libraryFile: portableHandle(data.libraryFile),
+    isLibraryFileGzipped: data.isLibraryFileGzipped,
+
+    preset: portablePreset(data.preset),
+    presetCommonName: data.presetCommonName,
+    isGenericPreset: data.isGenericPreset,
+    species: data.species,
+    customSpecies: data.customSpecies,
+    materialType: data.materialType,
+    leftAlignmentMode: data.leftAlignmentMode,
+    rightAlignmentMode: data.rightAlignmentMode,
+    tagPattern: data.tagPattern,
+    assembleClonesBy: data.assembleClonesBy,
+    imputeGermline: data.imputeGermline,
+    chains: data.chains,
+    scHeavyOnly: data.scHeavyOnly,
+    cloneClusteringMode: data.cloneClusteringMode,
+    exportMinQuality: data.exportMinQuality,
+    stopCodonTypes: data.stopCodonTypes,
+    stopCodonReplacements: data.stopCodonReplacements,
+
+    runMode: data.runMode,
+    limitInput: data.limitInput,
+    perProcessMemGB: data.perProcessMemGB,
+    perProcessCPUs: data.perProcessCPUs,
+
+    defaultBlockLabel: data.defaultBlockLabel,
+    customBlockLabel: data.customBlockLabel,
+    title: data.title,
+  }))
 
   .prerunArgs((data) => ({
     preset: data.preset,
@@ -109,7 +158,7 @@ export const platforma = BlockModelV3.create(dataModel)
   )
 
   .output("datasetSpec", (ctx) => {
-    if (ctx.data.inputLibrary) return ctx.resultPool.getSpecByRef(ctx.data.inputLibrary);
+    if (ctx.data.inputLibrary) return Column(ctx.data.inputLibrary)?.getSpec();
     else return undefined;
   })
 
@@ -150,9 +199,10 @@ export const platforma = BlockModelV3.create(dataModel)
   })
 
   .outputWithStatus("clones", (ctx) => {
-    const pColumns = ctx.outputs?.resolve("clonotypes")?.getPColumns();
-    if (pColumns === undefined) return undefined;
-    return ctx.createPFrame(pColumns);
+    const clonotypes = ctx.outputs?.resolve("clonotypes");
+    if (clonotypes === undefined) return undefined;
+    // Ids go straight to the host — no spec or data is pulled into the sandbox.
+    return ctx.createPFrame(ColumnsCollection([clonotypes]).getColumnIds());
   })
 
   .retentiveOutput("inputOptions", (ctx) => {
@@ -194,7 +244,7 @@ export const platforma = BlockModelV3.create(dataModel)
   .output("sampleLabels", (ctx): Record<string, string> | undefined => {
     const inputRef = ctx.data.input;
     if (inputRef === undefined) return undefined;
-    const inputSpec = ctx.resultPool.getSpecByRef(inputRef);
+    const inputSpec = Column(inputRef)?.getSpec();
     if (inputSpec === undefined || !isPColumnSpec(inputSpec)) return undefined;
     const sampleAxisSpec = inputSpec.axesSpec[0];
 
@@ -220,48 +270,46 @@ export const platforma = BlockModelV3.create(dataModel)
     return Object.fromEntries(
       Object.entries(
         sampleLabelsObj.obj.data.getDataAsJson<{ data: Record<string, string> }>().data,
-        // @TODO zod
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       ).map((e) => [JSON.parse(e[0])[0], e[1]]),
     ) as Record<string, string>;
   })
 
   .outputWithStatus("pt", (ctx) => {
-    const pCols = ctx.outputs
-      ?.resolve({ field: "qcReportTable", assertFieldType: "Input", allowPermanentAbsence: true })
-      ?.getPColumns();
-    if (pCols === undefined || pCols.length === 0) {
-      return undefined;
-    }
+    const qcReportTable = ctx.outputs?.resolve({
+      field: "qcReportTable",
+      assertFieldType: "Input",
+      allowPermanentAbsence: true,
+    });
+    if (qcReportTable === undefined) return undefined;
+    const collection = ColumnsCollection([qcReportTable]);
+    if (collection.isEmpty()) return undefined;
+    const cols = collection.getColumns();
+    if (cols.length === 0) return undefined;
     // Single primary column avoids V3's per-primary label-discovery collision on same-axis columns.
     return createPlDataTableV3(ctx, {
-      primaryColumns: [ColumnLazy.fromColumn(pCols[0])],
-      columns: pCols.slice(1).map((c) => ColumnLazy.fromColumn(c)),
+      primaryColumns: [cols[0]],
+      columns: cols.slice(1),
       tableState: ctx.data.tableState,
     });
   })
 
   .output("rawTsvs", (ctx) => {
-    if (ctx.outputs === undefined) return undefined;
-    const pCols = ctx.outputs?.resolve("clonotypeTables")?.getPColumns();
-    if (pCols === undefined) {
-      return undefined;
-    }
-    return pCols
-      .map((pCol) => {
-        return {
-          ...pCol,
-          id: (JSON.parse(pCol.id) as { name: string }).name,
-          data: parseResourceMap(pCol.data, (acc) => acc.getRemoteFileHandle(), false),
-        };
-      })
-      .filter((pCol) => pCol.data.isComplete)
-      .map((pCol) => {
-        return {
-          ...pCol,
-          data: pCol.data.data,
-        };
-      });
+    const clonotypeTables = ctx.outputs?.resolve("clonotypeTables");
+    if (clonotypeTables === undefined) return undefined;
+    return ColumnsCollection([clonotypeTables])
+      .getColumns()
+      .filter(isDataColumn)
+      .map((col) => ({
+        id: (JSON.parse(col.id) as { name: string }).name,
+        data: parseResourceMap(
+          asAccessor(col.getData()),
+          (acc) => acc.getRemoteFileHandle(),
+          false,
+        ),
+      }))
+      .filter((col) => col.data.isComplete)
+      .map((col) => ({ ...col, data: col.data.data }));
   })
 
   .output(
@@ -316,3 +364,24 @@ export * from "./progress";
 export * from "./qc";
 export * from "./reports";
 export { BlockArgs };
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+/** `parseResourceMap` needs the accessor arm of the column-data union. */
+function asAccessor(data: ColumnData): TreeNodeAccessor | undefined {
+  return data instanceof TreeNodeAccessor ? data : undefined;
+}
+
+/** Keeps a file handle only if it survives leaving this machine. */
+function portableHandle(handle: ImportFileHandle | undefined): ImportFileHandleIndex | undefined {
+  return handle !== undefined && isImportFileHandleIndex(handle) ? handle : undefined;
+}
+
+function portablePreset(preset: BlockData["preset"]): KindBlockParams["preset"] {
+  if (preset === undefined) return undefined;
+  if (preset.type === "name") return preset;
+  const file = portableHandle(preset.file);
+  return file === undefined ? undefined : { type: "file", file };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ catalogs:
       specifier: 1.1.0
       version: 1.1.0
     '@platforma-sdk/block-tools':
-      specifier: 2.14.0
-      version: 2.14.0
+      specifier: 2.14.2
+      version: 2.14.2
     '@platforma-sdk/model':
       specifier: 1.82.0
       version: 1.82.0
@@ -37,8 +37,8 @@ catalogs:
       specifier: 4.0.23
       version: 4.0.23
     '@platforma-sdk/test':
-      specifier: 1.82.0
-      version: 1.82.0
+      specifier: 1.82.3
+      version: 1.82.3
     '@platforma-sdk/ui-vue':
       specifier: 1.82.1
       version: 1.82.1
@@ -110,7 +110,7 @@ importers:
         version: 1.7.0(@types/node@24.10.2)(rollup@4.53.3)(vue@3.5.25(typescript@5.6.3))(yaml@2.8.2)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.14.0(@types/node@24.10.2)
+        version: 2.14.2(@types/node@24.10.2)
       js-yaml:
         specifier: 'catalog:'
         version: 4.1.1
@@ -146,7 +146,7 @@ importers:
         version: link:../workflow
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.14.0(@types/node@24.10.2)
+        version: 2.14.2(@types/node@24.10.2)
       '@platforma-sdk/model':
         specifier: 'catalog:'
         version: 1.82.0
@@ -183,7 +183,7 @@ importers:
         version: 1.4.0
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.14.0(@types/node@24.10.2)
+        version: 2.14.2(@types/node@24.10.2)
 
   model:
     dependencies:
@@ -211,7 +211,7 @@ importers:
         version: 1.4.0
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.14.0(@types/node@24.10.2)
+        version: 2.14.2(@types/node@24.10.2)
       '@types/node':
         specifier: '*'
         version: 24.10.2
@@ -248,7 +248,7 @@ importers:
         version: 1.4.0
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.82.0(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))
+        version: 1.82.3(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))
       eslint:
         specifier: 'catalog:'
         version: 9.39.1
@@ -325,7 +325,7 @@ importers:
         version: 4.0.23
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.82.0(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))
+        version: 1.82.3(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -1231,8 +1231,8 @@ packages:
   '@milaboratories/pl-http@1.2.4':
     resolution: {integrity: sha512-QKmhx+WEvJCV9dUy/SBdQk/ApaJ5ewBFgm/b+XPlS10SusAdqUUTGvK5+hq8YSuUMXlHb/dk++UtI5YlDuDl2Q==}
 
-  '@milaboratories/pl-middle-layer@1.67.0':
-    resolution: {integrity: sha512-T4+QXmlqG32y27z1fy5tIzBqs6DXij3JBhUYLZVnN7s6PTTDdKlj80V/ebt5Wysp2meoEP+B+sk84adE/FBeJA==}
+  '@milaboratories/pl-middle-layer@1.67.2':
+    resolution: {integrity: sha512-5SLP4UPMlAf8zLRWjZiWDioyFyBXnc0NxZvSUvL39Lc9h6tuk2MQ5ACUmXCSbBkFW1tV6dBGnc+50YdfTQ90gQ==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pl-model-backend@1.4.21':
@@ -1659,8 +1659,8 @@ packages:
   '@platforma-sdk/block-kind@1.1.0':
     resolution: {integrity: sha512-4uh+40o6BGfQcPPhkYGCjng8EXR9qn+6i5Fuc3RJ5QGfPYfcwbxT35G2V7ALUxmsqjLZ5SGL+JcW6Lm2v0cZHA==}
 
-  '@platforma-sdk/block-tools@2.14.0':
-    resolution: {integrity: sha512-sAsSDAHVAqlDn/QO+KuBnaVy/VomiHM4cI4ghylcY0Fq2CroVyz8Cm5YNw0SPINuUYmpzvVQuG9ili9Fn7uOog==}
+  '@platforma-sdk/block-tools@2.14.2':
+    resolution: {integrity: sha512-pYreKAu14sl/KKZZs0g/oldxUSvxPeBNc4QoxYHbdxhUykX78OsyL9/288QS8EcaltO+atblU/Zs7AtKaPvdVA==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
@@ -1678,8 +1678,8 @@ packages:
     engines: {node: '>=22'}
     hasBin: true
 
-  '@platforma-sdk/test@1.82.0':
-    resolution: {integrity: sha512-0fSW+Awn8FBfUDjFEAGL0HXqcJGzs5FpF3gUVcIxCY78Veiz9L6jUNncxB3pCO9ezYueVIXDDpPAETg4Hsvy6A==}
+  '@platforma-sdk/test@1.82.3':
+    resolution: {integrity: sha512-l621C70u97yw9MeSte4BV/BYjYYHiYt3IFwJZSLCfkGuDgXRXdYj8e5Leek17jmIe0YdVem/P/6DPtl1V4X74g==}
 
   '@platforma-sdk/ui-vue@1.82.1':
     resolution: {integrity: sha512-HCwLm+yN2cKbRL0caQ21+40mcodVGTmnruruNQAkcCkgHu4AaRmkEVRtel8AdHLpcqJS5ray341E1bqGErguSw==}
@@ -6441,7 +6441,7 @@ snapshots:
     dependencies:
       undici: 7.16.0
 
-  '@milaboratories/pl-middle-layer@1.67.0(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)':
+  '@milaboratories/pl-middle-layer@1.67.2(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)':
     dependencies:
       '@milaboratories/columns-collection-driver': 0.2.4
       '@milaboratories/computable': 2.9.8
@@ -6460,7 +6460,7 @@ snapshots:
       '@milaboratories/pl-tree': 1.13.7
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.8.6
-      '@platforma-sdk/block-tools': 2.14.0(@types/node@24.10.2)
+      '@platforma-sdk/block-tools': 2.14.2(@types/node@24.10.2)
       '@platforma-sdk/model': 1.82.0
       '@platforma-sdk/workflow-tengo': 6.8.2
       canonicalize: 2.1.0
@@ -7004,7 +7004,7 @@ snapshots:
 
   '@platforma-sdk/block-kind@1.1.0': {}
 
-  '@platforma-sdk/block-tools@2.14.0(@types/node@24.10.2)':
+  '@platforma-sdk/block-tools@2.14.2(@types/node@24.10.2)':
     dependencies:
       '@aws-sdk/client-ecr-public': 3.859.0
       '@aws-sdk/client-s3': 3.859.0
@@ -7073,11 +7073,11 @@ snapshots:
       commander: 15.0.0
       winston: 3.19.0
 
-  '@platforma-sdk/test@1.82.0(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))':
+  '@platforma-sdk/test@1.82.3(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))':
     dependencies:
       '@milaboratories/computable': 2.9.8
       '@milaboratories/pl-client': 3.14.7
-      '@milaboratories/pl-middle-layer': 1.67.0(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)
+      '@milaboratories/pl-middle-layer': 1.67.2(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)
       '@milaboratories/pl-tree': 1.13.7
       '@platforma-sdk/model': 1.82.0
       '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,35 +10,38 @@ catalogs:
       specifier: ^2.29.7
       version: 2.29.8
     '@milaboratories/helpers':
-      specifier: 1.14.4
-      version: 1.14.4
+      specifier: 1.14.5
+      version: 1.14.5
     '@milaboratories/ts-builder':
-      specifier: 1.6.0
-      version: 1.6.0
+      specifier: 1.7.0
+      version: 1.7.0
     '@milaboratories/ts-configs':
-      specifier: 1.3.0
-      version: 1.3.0
+      specifier: 1.4.0
+      version: 1.4.0
     '@platforma-open/milaboratories.samples-and-data':
       specifier: ^1.18.0
       version: 1.18.0
     '@platforma-open/milaboratories.software-mixcr':
       specifier: 4.7.0-347-develop
       version: 4.7.0-347-develop
+    '@platforma-sdk/block-kind':
+      specifier: 1.1.0
+      version: 1.1.0
     '@platforma-sdk/block-tools':
-      specifier: 2.12.7
-      version: 2.12.7
+      specifier: 2.14.0
+      version: 2.14.0
     '@platforma-sdk/model':
-      specifier: 1.80.2
-      version: 1.80.2
+      specifier: 1.82.0
+      version: 1.82.0
     '@platforma-sdk/tengo-builder':
-      specifier: 4.0.18
-      version: 4.0.18
+      specifier: 4.0.23
+      version: 4.0.23
     '@platforma-sdk/test':
-      specifier: 1.80.5
-      version: 1.80.5
+      specifier: 1.82.0
+      version: 1.82.0
     '@platforma-sdk/ui-vue':
-      specifier: 1.80.4
-      version: 1.80.4
+      specifier: 1.82.1
+      version: 1.82.1
     '@platforma-sdk/workflow-tengo':
       specifier: 6.8.2
       version: 6.8.2
@@ -57,6 +60,9 @@ catalogs:
     ag-grid-vue3:
       specifier: ~34.1.2
       version: 34.1.2
+    es-toolkit:
+      specifier: 1.42.0
+      version: 1.42.0
     eslint:
       specifier: ^9.38.0
       version: 9.39.1
@@ -101,10 +107,10 @@ importers:
         version: 2.29.8(@types/node@24.10.2)
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
-        version: 1.6.0(@types/node@24.10.2)(rollup@4.53.3)(vue@3.5.25(typescript@5.6.3))(yaml@2.8.2)
+        version: 1.7.0(@types/node@24.10.2)(rollup@4.53.3)(vue@3.5.25(typescript@5.6.3))(yaml@2.8.2)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.7(@types/node@24.10.2)
+        version: 2.14.0(@types/node@24.10.2)
       js-yaml:
         specifier: 'catalog:'
         version: 4.1.1
@@ -122,10 +128,13 @@ importers:
     devDependencies:
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
-        version: 1.6.0(@types/node@24.10.2)(rollup@4.53.3)(vue@3.5.25(typescript@5.6.3))(yaml@2.8.2)
+        version: 1.7.0(@types/node@24.10.2)(rollup@4.53.3)(vue@3.5.25(typescript@5.6.3))(yaml@2.8.2)
       '@milaboratories/ts-configs':
         specifier: 'catalog:'
-        version: 1.3.0
+        version: 1.4.0
+      '@platforma-open/milaboratories.mixcr-clonotyping-2.kind':
+        specifier: workspace:*
+        version: link:../kind
       '@platforma-open/milaboratories.mixcr-clonotyping-2.model':
         specifier: workspace:*
         version: link:../model
@@ -137,10 +146,10 @@ importers:
         version: link:../workflow
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.7(@types/node@24.10.2)
+        version: 2.14.0(@types/node@24.10.2)
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.80.2
+        version: 1.82.0
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -148,14 +157,45 @@ importers:
         specifier: 'catalog:'
         version: 5.6.3
 
+  kind:
+    dependencies:
+      '@platforma-sdk/block-kind':
+        specifier: 'catalog:'
+        version: 1.1.0
+      '@platforma-sdk/model':
+        specifier: 'catalog:'
+        version: 1.82.0
+      '@types/node':
+        specifier: '*'
+        version: 24.10.2
+      es-toolkit:
+        specifier: 'catalog:'
+        version: 1.42.0
+      typescript:
+        specifier: '*'
+        version: 5.9.3
+    devDependencies:
+      '@milaboratories/ts-builder':
+        specifier: 'catalog:'
+        version: 1.7.0(@types/node@24.10.2)(rollup@4.53.3)(vue@3.5.25(typescript@5.9.3))(yaml@2.8.2)
+      '@milaboratories/ts-configs':
+        specifier: 'catalog:'
+        version: 1.4.0
+      '@platforma-sdk/block-tools':
+        specifier: 'catalog:'
+        version: 2.14.0(@types/node@24.10.2)
+
   model:
     dependencies:
       '@milaboratories/helpers':
         specifier: 'catalog:'
-        version: 1.14.4
+        version: 1.14.5
+      '@platforma-open/milaboratories.mixcr-clonotyping-2.kind':
+        specifier: workspace:*
+        version: link:../kind
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.80.2
+        version: 1.82.0
       typescript:
         specifier: '*'
         version: 5.9.3
@@ -165,13 +205,13 @@ importers:
     devDependencies:
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
-        version: 1.6.0(@types/node@24.10.2)(rollup@4.53.3)(vue@3.5.25(typescript@5.9.3))(yaml@2.8.2)
+        version: 1.7.0(@types/node@24.10.2)(rollup@4.53.3)(vue@3.5.25(typescript@5.9.3))(yaml@2.8.2)
       '@milaboratories/ts-configs':
         specifier: 'catalog:'
-        version: 1.3.0
+        version: 1.4.0
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.7(@types/node@24.10.2)
+        version: 2.14.0(@types/node@24.10.2)
       '@types/node':
         specifier: '*'
         version: 24.10.2
@@ -192,7 +232,7 @@ importers:
         version: 1.18.0
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.80.2
+        version: 1.82.0
       this-block:
         specifier: workspace:@platforma-open/milaboratories.mixcr-clonotyping-2@*
         version: link:../block
@@ -202,13 +242,13 @@ importers:
     devDependencies:
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
-        version: 1.6.0(@types/node@24.10.2)(rollup@4.53.3)(vue@3.5.25(typescript@5.9.3))(yaml@2.8.2)
+        version: 1.7.0(@types/node@24.10.2)(rollup@4.53.3)(vue@3.5.25(typescript@5.9.3))(yaml@2.8.2)
       '@milaboratories/ts-configs':
         specifier: 'catalog:'
-        version: 1.3.0
+        version: 1.4.0
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.80.5(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))
+        version: 1.82.0(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))
       eslint:
         specifier: 'catalog:'
         version: 9.39.1
@@ -220,16 +260,16 @@ importers:
     dependencies:
       '@milaboratories/helpers':
         specifier: 'catalog:'
-        version: 1.14.4
+        version: 1.14.5
       '@platforma-open/milaboratories.mixcr-clonotyping-2.model':
         specifier: workspace:*
         version: link:../model
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.80.2
+        version: 1.82.0
       '@platforma-sdk/ui-vue':
         specifier: 'catalog:'
-        version: 1.80.4(@bytecodealliance/preview2-shim@0.17.9)(typescript@5.9.3)
+        version: 1.82.1(@bytecodealliance/preview2-shim@0.17.9)(typescript@5.9.3)
       '@types/node':
         specifier: '*'
         version: 24.10.2
@@ -257,10 +297,10 @@ importers:
     devDependencies:
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
-        version: 1.6.0(@types/node@24.10.2)(rollup@4.53.3)(vue@3.5.24(typescript@5.9.3))(yaml@2.8.2)
+        version: 1.7.0(@types/node@24.10.2)(rollup@4.53.3)(vue@3.5.24(typescript@5.9.3))(yaml@2.8.2)
       '@milaboratories/ts-configs':
         specifier: 'catalog:'
-        version: 1.3.0
+        version: 1.4.0
       '@types/wicg-file-system-access':
         specifier: 'catalog:'
         version: 2023.10.7
@@ -282,10 +322,10 @@ importers:
     devDependencies:
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
-        version: 4.0.18
+        version: 4.0.23
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.80.5(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))
+        version: 1.82.0(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -889,12 +929,12 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@grpc/grpc-js@1.13.4':
-    resolution: {integrity: sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==}
+  '@grpc/grpc-js@1.14.4':
+    resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
     engines: {node: '>=12.10.0'}
 
-  '@grpc/proto-loader@0.7.15':
-    resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
+  '@grpc/proto-loader@0.8.1':
+    resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
     engines: {node: '>=6'}
     hasBin: true
 
@@ -1068,20 +1108,20 @@ packages:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
 
-  '@jitl/quickjs-ffi-types@0.31.0':
-    resolution: {integrity: sha512-1yrgvXlmXH2oNj3eFTrkwacGJbmM0crwipA3ohCrjv52gBeDaD7PsTvFYinlAnqU8iPME3LGP437yk05a2oejw==}
+  '@jitl/quickjs-ffi-types@0.32.0':
+    resolution: {integrity: sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg==}
 
-  '@jitl/quickjs-wasmfile-debug-asyncify@0.31.0':
-    resolution: {integrity: sha512-YkdzQdr1uaftFhgEnTRjTTZHk2SFZdpWO7XhOmRVbi6CEVsH9g5oNF8Ta1q3OuSJHRwwT8YsuR1YzEiEIJEk6w==}
+  '@jitl/quickjs-wasmfile-debug-asyncify@0.32.0':
+    resolution: {integrity: sha512-EX8zbXwGqCgAE764M+qvkHtyXDi/FUoMBea0JnES7vCM3P7a2+EOZOjGv85wtZ2sJhI1oJ+nekmqpOODFDY+hw==}
 
-  '@jitl/quickjs-wasmfile-debug-sync@0.31.0':
-    resolution: {integrity: sha512-8XvloaaWBONqcHXYs5tWOjdhQVxzULilIfB2hvZfS6S+fI4m2+lFiwQy7xeP8ExHmiZ7D8gZGChNkdLgjGfknw==}
+  '@jitl/quickjs-wasmfile-debug-sync@0.32.0':
+    resolution: {integrity: sha512-LeYWrPGC1uNCTBWvibo3ZLJj0CSVNYUXvJpXMCmuQ5Sap2cCACc3uvGvYV4homHHBAzfw5akoTqMMS4YFRtw+Q==}
 
-  '@jitl/quickjs-wasmfile-release-asyncify@0.31.0':
-    resolution: {integrity: sha512-uz0BbQYTxNsFkvkurd7vk2dOg57ElTBLCuvNtRl4rgrtbC++NIndD5qv2+AXb6yXDD3Uy1O2PCwmoaH0eXgEOg==}
+  '@jitl/quickjs-wasmfile-release-asyncify@0.32.0':
+    resolution: {integrity: sha512-3oSwPfja12ICz4aIblB58cuY8JlEq5Txt8Cut4VLo+LH47QN+mzCnSgnbB03hWzg1LBcc+VyyI9UOag7a1NF+Q==}
 
-  '@jitl/quickjs-wasmfile-release-sync@0.31.0':
-    resolution: {integrity: sha512-hYduecOByj9AsAfsJhZh5nA6exokmuFC8cls39+lYmTCGY51bgjJJJwReEu7Ff7vBWaQCL6TeDdVlnp2WYz0jw==}
+  '@jitl/quickjs-wasmfile-release-sync@0.32.0':
+    resolution: {integrity: sha512-BKNDI/TPBfGlLNGYpLrhcDGXmIk4xHm4MRAisOBnOzpXVn9HZWsfmMAc9WMBrAHjvvds6HOikKeaOBKdPdpVrg==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1126,101 +1166,96 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
-  '@milaboratories/columns-collection-driver@0.2.1':
-    resolution: {integrity: sha512-CYdDAhmB01jYq0IXJmbMbA/yTfqSkzwRs0ZJxoSvnzvlu1doc63VIXSvhHOw9b70usR5EFVprR2PvPMTRnjeQQ==}
+  '@milaboratories/columns-collection-driver@0.2.4':
+    resolution: {integrity: sha512-abbgAzME71ARvgnGQHte+dPMgt2JGBJN4YpGLVxiYr7GToHwypsEi3PY/dAqriQWRtpKR82EpIAMxXVq0d7XMw==}
 
-  '@milaboratories/computable@2.9.7':
-    resolution: {integrity: sha512-uCMretdt4okbKWkU0aZ0+NHH3hN0wzi2ZIkAvwqha0ZTxUqKilDOlZNAL6QLbmT/7vQs9geAj4amlwSgzkMoww==}
+  '@milaboratories/computable@2.9.8':
+    resolution: {integrity: sha512-X0ZtxOnIJlAd9Y7CyBtWSKHgVuTKXbIryMwJaoYSEz0gY3JZVnsD0f59J/lwe3Key0/lSYh3EbL/pP5jACIzfQ==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/helpers@1.14.2':
     resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
     engines: {node: '>=22'}
 
-  '@milaboratories/helpers@1.14.4':
-    resolution: {integrity: sha512-0mS5GQAQYUab0qj1C6+IXafNJhL1ahnhPBmIkLq9VqJU8p9jNZ7KC5ln4/pl0tK47brdPljCLEiLg8IdSa6wFw==}
+  '@milaboratories/helpers@1.14.5':
+    resolution: {integrity: sha512-Kiy0g7sEmFQxDwtnmTrdJ8XdUK0IDAB5ZnPCNEbK7lPGHIa+xG3kzfeR4y44QBdrYaK0NwG63D8Fc7dlv9KItg==}
     engines: {node: '>=22'}
 
-  '@milaboratories/pf-driver@1.8.2':
-    resolution: {integrity: sha512-K5jKzqFfsOJL051U1VAg2Iy9iE01Hwm+FtRb2/PcB0DV3VItIozXRF/mvcXKDHbSCLcPcRGqZjtEF3kMczd+sA==}
+  '@milaboratories/pf-driver@1.9.1':
+    resolution: {integrity: sha512-i4qt1kcOcvOAHGlA7tCHce1QpsvmrCDu2vvmZz/kfHPma7YyDU7PSSr6hhuV+rf7HZTJz7z193c7wCXTFTLrzQ==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pf-spec-driver@1.4.21':
-    resolution: {integrity: sha512-JuYVQKs4aia8DA8MVqdImu+Ho+uTwwOqIaJ3VVPMpCMo3QAH9jZP+wGlkklSwow4d+27Y8L2RJN/1dcPr56GZw==}
+  '@milaboratories/pf-spec-driver@1.5.1':
+    resolution: {integrity: sha512-K7BuQCUXqpUOAwgJ1aIO8SSQbE8RSEVb8J5e6vIpI6PqV7Uc8LHFswTguOSgSuacpMgQmEP9jmIKyafJdJ7PDw==}
 
-  '@milaboratories/pframes-rs-node@1.1.55':
-    resolution: {integrity: sha512-TbudDPMixADLyVr5UsiXhf+zq7YCJA3osFrzDn7Lr5aeyorCjiXDkVOGKpID7GkkssuVsNpPXtoGdA71Y2tLjQ==}
+  '@milaboratories/pf-spec@1.0.1':
+    resolution: {integrity: sha512-UbLycglulwrFgil6n1By17YGOVHzZXeb+tAVUej6ZFOmpRtAMQYVLOXAX4FN2tc98eDTJ+YrYdZCa7qWi1gBxw==}
+    peerDependencies:
+      '@bytecodealliance/preview2-shim': ^0.20.1
 
-  '@milaboratories/pframes-rs-serv@1.1.55':
-    resolution: {integrity: sha512-cGByUULBA/JiwyFEBZrVNOEbnbrMPWWHCWLprRKlVWlmDMaRmsVft/tFpnle46BhDZWpoWbaKEZ8NGOtGqDCXw==}
+  '@milaboratories/pframes-rs-node@1.1.56':
+    resolution: {integrity: sha512-H6qltcR+HHb2kAy0U0zP90rqmv/MZGGkdXIyf89FUZTpoHOlXG4Ahxq7wXp9vviUczci4cLl2L0Q+dL2XGcsUA==}
+
+  '@milaboratories/pframes-rs-serv@1.1.56':
+    resolution: {integrity: sha512-Pi0CRuvkfL+PqdgQ8im0MW5tqVjUvJ8hJbOG7v5pS45adg8tuq4TyrAoWN7un9ZWQ6KRLypUD+7eXCwhjOwADg==}
     hasBin: true
-
-  '@milaboratories/pframes-rs-wasip2@1.1.55':
-    resolution: {integrity: sha512-mwKTmcDiuN6Id2h+oxKX2W5igFhMxDvRZs4clsxhPTYZASSROrvsSsaoXS81meqfC0phx+BUaRpdrkVQIKSdxQ==}
 
   '@milaboratories/pframes-rs-wasip2@1.1.56':
     resolution: {integrity: sha512-54bhC6XCAVO09J/sqVwEKA4hhTa27BDDNdH8BE+6+LvjBVkg/qq2/f0MzdrVijrmagbr97F1zgj5wIgUqwCSoA==}
 
-  '@milaboratories/pframes-rs-wasm@1.1.55':
-    resolution: {integrity: sha512-kVOL+eAasfeiui5lQ5G92nsSiTNSsOnl1m+4my0tmbR7VTCa15dn1kd5RcXS3/8YO5oEcnGlCUhnu5kKMtweEw==}
-    peerDependencies:
-      '@bytecodealliance/preview2-shim': 0.17.9
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-model-middle-layer': 1.30.7
-
-  '@milaboratories/pl-client@3.14.2':
-    resolution: {integrity: sha512-+0ih1njQn4wvLjGmFKboKFRlWYLrzg7QdRK2aNo8ivTKY16TrsMRCk0GQEt0aPKELnv7QSrsNSjg7e7GSdGMDQ==}
+  '@milaboratories/pl-client@3.14.7':
+    resolution: {integrity: sha512-HIjPfGAYRRD0hbq5YSTkWt5XgBiv+yYtw73EjWLxui8eUEeB2ffdgsvH7IhVx2oXjUOL4p7M4i8PBnmdJ3830w==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-config@1.8.4':
-    resolution: {integrity: sha512-eBZCIVhl9jRigyJUPURCxH2f2OrU5aToihSrwmTkCOu2rjr1spe4YGMIh9CxPr8Z1GkfQbez3crJGME1+RZrrg==}
+  '@milaboratories/pl-config@1.8.5':
+    resolution: {integrity: sha512-XnfYXSSkRxeImQ21k6I8y5apisvagcSgMGfEeyRxNdSGwUVJbbI8TwJk+XBEDQ4lErW8oqtLxKjFQuHJMzRUoQ==}
 
-  '@milaboratories/pl-deployments@3.0.12':
-    resolution: {integrity: sha512-Oo7MGAwMyC8F5zCZWgs3Q/sET584Ussux8YP6TB+UBfWcNwZVZWbiO/QaRewfjnMfKSJ4Uden7RoQ4hHWvWChA==}
+  '@milaboratories/pl-deployments@3.0.16':
+    resolution: {integrity: sha512-nFAIY4rxAssVqicSzgSNVQB/ZOjHjh4uhvde8aWFqQcMZCQDhHSaVJezzxRdotS8JiY5kI4r/Y0cN+Ey1MDDog==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-drivers@1.16.10':
-    resolution: {integrity: sha512-5lrewLkmN9Z6dWkRw2kYbsjquHNSHBni8seTI3BsP9xijuv4NzEkvDcJLJsQsuZcuaFtyw77fHAKvNmlYZiJeA==}
+  '@milaboratories/pl-drivers@1.16.16':
+    resolution: {integrity: sha512-Z60p02vIPmdy/M10gacg6I2BZ2T/gySPMm2Q8IbfvCbUJRjXXfbkGxN8hBoeRQShcXgM5svu0hPZfv1e87QRmQ==}
     engines: {node: '>=22'}
 
   '@milaboratories/pl-error-like@1.12.10':
     resolution: {integrity: sha512-iHmnLG5lxJqcymUmEL8onCDGEADk1S/5RNACQ5yfTCNcCkUc+7hYrDHQpFmWXPPGC9sG+NTBxt4wr5m8UsLm2g==}
 
-  '@milaboratories/pl-errors@1.4.31':
-    resolution: {integrity: sha512-XK4npZNtHksD+IHuzsaf4SXtceqRpwCH/PxZy7zijFqNuW5cdl7be8Parr8T+wQzYaDgHLVSKrYilzC56RNx/Q==}
+  '@milaboratories/pl-errors@1.4.36':
+    resolution: {integrity: sha512-WzKECX8Te6uP2DT7z2yTN6RrkiAWowYeU1rmB1Uc6sQBBWC6OjiqjiyOjvFeqxi73oXODARhLaLnqJcpG1onNA==}
 
-  '@milaboratories/pl-healthcheck@1.0.3':
-    resolution: {integrity: sha512-krt75tuov2T0TKAsybbSzwHt45JjAQJbnqya0FiRApme913k6DvoowEX2NYLzRChbn+QVbs4ODxJI8lcgFexVg==}
+  '@milaboratories/pl-healthcheck@1.0.5':
+    resolution: {integrity: sha512-ZkQti4VU2FapJBFRtZGfR5NDPXEAEFgTf/NfemypgY0aA75fFPi4/c3BpXX5K7dht+JOgHqkMrBHxKIuE2T+fA==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pl-http@1.2.4':
     resolution: {integrity: sha512-QKmhx+WEvJCV9dUy/SBdQk/ApaJ5ewBFgm/b+XPlS10SusAdqUUTGvK5+hq8YSuUMXlHb/dk++UtI5YlDuDl2Q==}
 
-  '@milaboratories/pl-middle-layer@1.66.4':
-    resolution: {integrity: sha512-rFyxoWpFNjA5FPU6A5Usf0FyDx+XzFSsDqsPRf3NVuxrk6No6cNGZVUerdpXZJ6qCEsJwdgMBRECyBI5MV5bRw==}
+  '@milaboratories/pl-middle-layer@1.67.0':
+    resolution: {integrity: sha512-T4+QXmlqG32y27z1fy5tIzBqs6DXij3JBhUYLZVnN7s6PTTDdKlj80V/ebt5Wysp2meoEP+B+sk84adE/FBeJA==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-model-backend@1.4.16':
-    resolution: {integrity: sha512-MrJwM3aOzrqr3+GVpS/1Zh/SOH/2tBtoyk/+eE6C7LRjofoip8GIF4be8AgPAM3C+6wTSGrQ5x3CM6A8Ql2HVA==}
+  '@milaboratories/pl-model-backend@1.4.21':
+    resolution: {integrity: sha512-Z2z5J8bglslgXXoi1aySi1ho+/d+ylJiuEaRw9XTNuE5iBM3EQPe0rw095pXGOinTlMpmvUcCI2wkVCraUQ1dA==}
 
   '@milaboratories/pl-model-common@1.46.2':
     resolution: {integrity: sha512-VEeauisApYScvCS8lnK3zpFJ520xuTAodKJmjR8ulHcMrWMyWMfHEdGb7j5OMD0mM/OwTgmQrrJ5eB7Xd+xoOQ==}
 
-  '@milaboratories/pl-model-common@1.47.1':
-    resolution: {integrity: sha512-5F9I8JvUPRJ2HEzz5MmTio6JFYnhYoMVHfToh2NyXyOyQgAF6jhOzZBOsrEig9NfCPZBRB7v6UjmIK43dG4o/g==}
-
-  '@milaboratories/pl-model-middle-layer@1.30.13':
-    resolution: {integrity: sha512-owQVozyub/6aKgk+yce+9sDK+t0HrpLbnlKJqQjYJahuhoju8j6VMY17AWgvADSDCiI3gnp/Tm/I4Ur6ySs1Cg==}
+  '@milaboratories/pl-model-common@1.48.0':
+    resolution: {integrity: sha512-oCVrjFNmjQolb7YWnbSGHnp6GGVm1PhG1lnNABp9lqYjvA2ISjIPQLIo/vT2ca0mqwLrEvbuRqiqSFOg7sQ5tQ==}
 
   '@milaboratories/pl-model-middle-layer@1.30.7':
     resolution: {integrity: sha512-rs9x3Ron4ujR/UOdEgB8WUB1SvZ8ZAScT1Av/e4or+iiQ/CzhmK9nqtYamHVwKV+JgwIFbXQwxGvIHDVz955dQ==}
 
-  '@milaboratories/pl-tree@1.13.1':
-    resolution: {integrity: sha512-NtVVUSF9eJA5v5iUEfGgKl0JbG/EIvy+YCsxzCZ1dXG1S3gCNwt01Nj5PkWW7FkDG1IT0ZfwyeO0mVVz2kIv1Q==}
+  '@milaboratories/pl-model-middle-layer@1.32.0':
+    resolution: {integrity: sha512-X1iLGgOwzkw8mQ/GfTxfOTJakBJ26np85h5HqUziMbVkFL0SR7wpd7xpgUs6TKVkYNM8viAv3iA2k63Yc5SahQ==}
+
+  '@milaboratories/pl-tree@1.13.7':
+    resolution: {integrity: sha512-q4pURdiq7cwOV1TAkIa6fZo3s3mzglBSokLgBSmoBPtnj9bsna5nTrqQFqp9KCzPb9N9PbTRE75du+I5YDbc+g==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/ptabler-expression-js@1.2.35':
-    resolution: {integrity: sha512-nTVNYgNHuUswPnAe8GFAitbewNVMHaxhAncQ3yMYfGzsGgZupQyGV6K1DHVkzMAwNwVFVLwIbiPMY58en03XWQ==}
+  '@milaboratories/ptabler-expression-js@1.2.38':
+    resolution: {integrity: sha512-z14oa/V3nkBGHxnygpfxUBU7EfHQKHh1KZgK47ouqIw7CvuOmqjViRdynY4HZNjAh3n3AGHpBbEFs/J+hQMW3g==}
 
   '@milaboratories/resolve-helper@1.1.3':
     resolution: {integrity: sha512-38/dW/XRZQREOxAOOKtO0lzEWPCP/DH0qhB3q1kYcGoN++5V92/zbVwbYrMDeDcjTyo+D62iIep+sKXeWHa7Uw==}
@@ -1233,25 +1268,19 @@ packages:
     os: [darwin, linux, win32]
     hasBin: true
 
-  '@milaboratories/ts-builder@1.6.0':
-    resolution: {integrity: sha512-OlQ38jsriFf7qS5AmNIch65qQAOZBRFaLT15N/JJqe9dIytKJNS8Ff9G4vowWtFiRzyeyWRArBtgVOeAmoYuKQ==}
+  '@milaboratories/ts-builder@1.7.0':
+    resolution: {integrity: sha512-VT8xf4jZg2Dyo6KR5s+z4WiHrVfAJ46d7N39k7JPNlOlig910/h/1LKgXSgWysWfAp+2pYKvq7flAu3JKLKarg==}
     hasBin: true
 
-  '@milaboratories/ts-configs@1.3.0':
-    resolution: {integrity: sha512-6rZaMOJotG+v6eXoupHgPqxArpNBNl0f7sd5K+kUo1PUhPTe632eLJtEeBbFtwDGNYqL9QUacd4pT5t6oDOf0A==}
+  '@milaboratories/ts-configs@1.4.0':
+    resolution: {integrity: sha512-VzU9D+RiggsG4VYteJSBN4o8IjYae9GbZ8MofikMJQLOI1Ir9/pVyPXXGnG/TAGvmcjbK/psAiZVGSvI5MBPGg==}
 
-  '@milaboratories/ts-helpers@1.8.5':
-    resolution: {integrity: sha512-vZDcIBta7I935VjKk6qGdhpjz2pWXe5CbWv1UUmPrcG8wsunDpWuet8/Gi75N97CpcLDc2LLHd/url9K8ZNpAg==}
+  '@milaboratories/ts-helpers@1.8.6':
+    resolution: {integrity: sha512-ef01tARUl+0Urt3x8HHAByrhYHg4Rnn7WiFyJ+joZFZl1T1pUKTgfB7Zxc8Cn06HIl4i6H7s5OSymjZePIGqfQ==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/uikit@2.15.16':
-    resolution: {integrity: sha512-HOl1YsPKHpj3izKAs0hEvVtFE8ZbrOnD5KsAqSHxvipQyfAdOLbfB7ak6XPdPKbgsvH5opfMws7usryR6Nlulw==}
-
-  '@napi-rs/wasm-runtime@1.1.3':
-    resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
+  '@milaboratories/uikit@2.15.24':
+    resolution: {integrity: sha512-/NFdh4fcxhArGToWn4kSvSTuOEpFSjfDErPC4bkNXQ0UV633etU+v/vV81J+oSC/BlyCc5Rire9qLHhut18g+w==}
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -1600,17 +1629,11 @@ packages:
   '@platforma-open/milaboratories.software-mixcr@4.7.0-347-develop':
     resolution: {integrity: sha512-4GlZWEhs2CxZu9GjswUA8dT0VD5M6x1pxa3iz1AgkrFx3deDHt0pJQcazJuAE0Pgm4GcyRX9p/Yf0TRmexbcmQ==}
 
-  '@platforma-open/milaboratories.software-ptabler.schema@1.15.19':
-    resolution: {integrity: sha512-h/FBLELZT6PJZnWtwvcy8bQrpZ2A6xWSVSjyccqb3QolHSbeuwi5UpUph8UxdDYNmWSCH0zR/zE2hFypgk21xA==}
-
-  '@platforma-open/milaboratories.software-ptabler@2.1.6':
-    resolution: {integrity: sha512-LdDU9/z+iejw5F98J8DYVQKsjUGGiyu8rHWCjWCEqOVEP+N9QBcN4ibDgG4Xp/GL+IzKxicAkf2Ae9lHollD6w==}
+  '@platforma-open/milaboratories.software-ptabler.schema@1.15.22':
+    resolution: {integrity: sha512-f9vT+iSfNelgAGjaNzn1GErhmxHbjG6HtskAMoaUEbrciCG8c8i8cSCJPLu0xKNBcjM1UW+T10uD89Ckq2vkxQ==}
 
   '@platforma-open/milaboratories.software-ptabler@2.1.8':
     resolution: {integrity: sha512-28dKwcKNIB/8OYH6l/li7Qa/aE2NgDVtNUmN8v6jZsLKT59ogFclz8ZrQ+OiQFzHQCLBlWBt5TdIHfHPxBaNFw==}
-
-  '@platforma-open/milaboratories.software-ptexter@1.2.3':
-    resolution: {integrity: sha512-5wwzvPko/tjkm6EnirsnjB+MO5mF//tgJplI+jPh3bcSHpEdHF+B9xg+S1owAnekqbimMrFZWqHSVY9ZmIHOjw==}
 
   '@platforma-open/milaboratories.software-ptexter@1.2.4':
     resolution: {integrity: sha512-4ZqhqksSNVKWhEB9WwrL0rU89G+00ulzH1urYyNA4EdBVGA4mwbKbw0K/zcwce/oUYYMdRl+epXmr0w9wHyNzA==}
@@ -1633,33 +1656,33 @@ packages:
   '@platforma-open/milaboratories.software-small-binaries@2.1.1':
     resolution: {integrity: sha512-KN1PR7YgUUfx1dxh/TtcoWpSZbOXbRxXzQuJ505qHuXuE0spYwC7bXnvJsEYbEwRcPMa0foTrjBnPNORE4yr+Q==}
 
-  '@platforma-sdk/block-tools@2.12.7':
-    resolution: {integrity: sha512-a13K0hcXYf+sgx+07QFjIu2uTeTH5lhHHI1o563kvs9Z5vssU9jn7HFgXgSe6TMjDntERJcGHiGm8nUd4t3FiA==}
+  '@platforma-sdk/block-kind@1.1.0':
+    resolution: {integrity: sha512-4uh+40o6BGfQcPPhkYGCjng8EXR9qn+6i5Fuc3RJ5QGfPYfcwbxT35G2V7ALUxmsqjLZ5SGL+JcW6Lm2v0cZHA==}
+
+  '@platforma-sdk/block-tools@2.14.0':
+    resolution: {integrity: sha512-sAsSDAHVAqlDn/QO+KuBnaVy/VomiHM4cI4ghylcY0Fq2CroVyz8Cm5YNw0SPINuUYmpzvVQuG9ili9Fn7uOog==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
     resolution: {integrity: sha512-p9lBxhFXM9WoRsrJO7dfkiXSK+1m63yIn1sKhBO71eMbhrLMyVYHEOeNf3w5OCdbRF5QsNhXzWuiTmFK3zHFsA==}
     hasBin: true
 
-  '@platforma-sdk/model@1.80.2':
-    resolution: {integrity: sha512-aQGVxjxw7y34U0ZuboIYASodJMZ1yTjXH2y44bCdeTeS/r81YBBmGrF6BQhHHVjIOIhaIlWHRBIhd9AJo42aWQ==}
+  '@platforma-sdk/model@1.82.0':
+    resolution: {integrity: sha512-m2GQFYQUS+XivC+Bsan9UlTvOM7R4wraF0eWMwQiZt3yjCSw09z12Be0uydTKLGVvLPbsw7zjhibMop3eBTb1w==}
 
-  '@platforma-sdk/package-builder-lib@1.2.0':
-    resolution: {integrity: sha512-AtSzaZ39BGlqcyYtpGREDz+YlGCDdSTQJNV/+NkTyUtoq1ECRO+iMqAX1DSSza1WqylnURX8vKVI2owS/cxntA==}
+  '@platforma-sdk/package-builder-lib@1.3.0':
+    resolution: {integrity: sha512-CdBjmNo6E1fBxKYWaXa49L/L2WLURxs2f1TAqxLIZlHRE4DZ6E1TEj3jNNKESWp+/9rwtLkTAzmTzNPrDgz+2Q==}
 
-  '@platforma-sdk/tengo-builder@4.0.18':
-    resolution: {integrity: sha512-nGPB5fE6b9ITFuXVMRakr2MyqsnL4TVE09jZ2X7TCPgb31k4gIhYCT+XU9vBRavBj/U3dt+jSWHkcbX9JvJKYA==}
+  '@platforma-sdk/tengo-builder@4.0.23':
+    resolution: {integrity: sha512-Qkxpg3wuZQOc6KbEL3pifOCdqOH91TaL3jDluVIm5mz3qpx96KO+To8AT/0nLqmvaF7yv8AP22QiyyqduAhGiw==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@platforma-sdk/test@1.80.5':
-    resolution: {integrity: sha512-z3tBrNWIg0+OfUOKpiZWCFflSW17J/Tv7DRWK99IzaaS0+MrIhC6oEFJGXnDlbynhnhSp3E+a4HiwEe+SG/rCg==}
+  '@platforma-sdk/test@1.82.0':
+    resolution: {integrity: sha512-0fSW+Awn8FBfUDjFEAGL0HXqcJGzs5FpF3gUVcIxCY78Veiz9L6jUNncxB3pCO9ezYueVIXDDpPAETg4Hsvy6A==}
 
-  '@platforma-sdk/ui-vue@1.80.4':
-    resolution: {integrity: sha512-DQbuO3fAJ3CQxiJkXMiNuo1Qyd/C92AatOZX90ElLFohXiP3XbJNXNjrIxypzsUc850dKkqbPjKd0JTzD12E9w==}
-
-  '@platforma-sdk/workflow-tengo@6.7.2':
-    resolution: {integrity: sha512-KJ4tBigEDN+EIDy7K2u7PqxBIDrhwvnazJthApGg2N/HPZkinKmq0iMzHC9KZ0IsJVg6uxECIB2d2Acko33tOw==}
+  '@platforma-sdk/ui-vue@1.82.1':
+    resolution: {integrity: sha512-HCwLm+yN2cKbRL0caQ21+40mcodVGTmnruruNQAkcCkgHu4AaRmkEVRtel8AdHLpcqJS5ray341E1bqGErguSw==}
 
   '@platforma-sdk/workflow-tengo@6.8.2':
     resolution: {integrity: sha512-AHR/Y+vbyfda17A7xY2uH9TlXiBpM8242tTO6+lj8phA4/KS6mez4GLu4ZEaASlZpX6YkQsUs5LUxYQU7pXeiQ==}
@@ -1689,20 +1712,17 @@ packages:
   '@protobufjs/base64@1.1.2':
     resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
 
-  '@protobufjs/codegen@2.0.4':
-    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
 
-  '@protobufjs/eventemitter@1.1.0':
-    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
 
-  '@protobufjs/fetch@1.1.0':
-    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
 
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
-
-  '@protobufjs/inquire@1.1.0':
-    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
 
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
@@ -1710,8 +1730,8 @@ packages:
   '@protobufjs/pool@1.1.0':
     resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
 
-  '@protobufjs/utf8@1.1.0':
-    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.13':
     resolution: {integrity: sha512-5ZiiecKH2DXAVJTNN13gNMUcCDg4Jy8ZjbXEsPnqa248wgOVeYRX0iqXXD5Jz4bI9BFHgKsI2qmyJynstbmr+g==}
@@ -2279,9 +2299,6 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
-
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -4143,8 +4160,8 @@ packages:
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
   pump@3.0.3:
@@ -4167,11 +4184,11 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  quickjs-emscripten-core@0.31.0:
-    resolution: {integrity: sha512-oQz8p0SiKDBc1TC7ZBK2fr0GoSHZKA0jZIeXxsnCyCs4y32FStzCW4d1h6E1sE0uHDMbGITbk2zhNaytaoJwXQ==}
+  quickjs-emscripten-core@0.32.0:
+    resolution: {integrity: sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg==}
 
-  quickjs-emscripten@0.31.0:
-    resolution: {integrity: sha512-K7Yt78aRPLjPcqv3fIuLW1jW3pvwO21B9pmFOolsjM/57ZhdVXBr51GqJpalgBlkPu9foAvhEAuuQPnvIGvLvQ==}
+  quickjs-emscripten@0.32.0:
+    resolution: {integrity: sha512-So0Sqw869y/S2oE3Nuc0uT3Dhqgvsj8FSrwBdsuTosVsG8ME5/OcudU1GxsrIFdFABgy17GHnTVO9TYV/bLQcA==}
     engines: {node: '>=16.0.0'}
 
   rc@1.2.8:
@@ -5995,16 +6012,16 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@grpc/grpc-js@1.13.4':
+  '@grpc/grpc-js@1.14.4':
     dependencies:
-      '@grpc/proto-loader': 0.7.15
+      '@grpc/proto-loader': 0.8.1
       '@js-sdsl/ordered-map': 4.4.2
 
-  '@grpc/proto-loader@0.7.15':
+  '@grpc/proto-loader@0.8.1':
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.4
+      protobufjs: 7.6.5
       yargs: 17.7.2
 
   '@humanfs/core@0.19.1': {}
@@ -6164,23 +6181,23 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
-  '@jitl/quickjs-ffi-types@0.31.0': {}
+  '@jitl/quickjs-ffi-types@0.32.0': {}
 
-  '@jitl/quickjs-wasmfile-debug-asyncify@0.31.0':
+  '@jitl/quickjs-wasmfile-debug-asyncify@0.32.0':
     dependencies:
-      '@jitl/quickjs-ffi-types': 0.31.0
+      '@jitl/quickjs-ffi-types': 0.32.0
 
-  '@jitl/quickjs-wasmfile-debug-sync@0.31.0':
+  '@jitl/quickjs-wasmfile-debug-sync@0.32.0':
     dependencies:
-      '@jitl/quickjs-ffi-types': 0.31.0
+      '@jitl/quickjs-ffi-types': 0.32.0
 
-  '@jitl/quickjs-wasmfile-release-asyncify@0.31.0':
+  '@jitl/quickjs-wasmfile-release-asyncify@0.32.0':
     dependencies:
-      '@jitl/quickjs-ffi-types': 0.31.0
+      '@jitl/quickjs-ffi-types': 0.32.0
 
-  '@jitl/quickjs-wasmfile-release-sync@0.31.0':
+  '@jitl/quickjs-wasmfile-release-sync@0.32.0':
     dependencies:
-      '@jitl/quickjs-ffi-types': 0.31.0
+      '@jitl/quickjs-ffi-types': 0.32.0
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -6268,30 +6285,30 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@milaboratories/columns-collection-driver@0.2.1':
+  '@milaboratories/columns-collection-driver@0.2.4':
     dependencies:
-      '@milaboratories/helpers': 1.14.4
-      '@milaboratories/pl-model-common': 1.47.1
+      '@milaboratories/helpers': 1.14.5
+      '@milaboratories/pl-model-common': 1.48.0
 
-  '@milaboratories/computable@2.9.7':
+  '@milaboratories/computable@2.9.8':
     dependencies:
       '@milaboratories/pl-error-like': 1.12.10
-      '@milaboratories/ts-helpers': 1.8.5
+      '@milaboratories/ts-helpers': 1.8.6
       '@types/node': 24.5.2
       utility-types: 3.11.0
 
   '@milaboratories/helpers@1.14.2': {}
 
-  '@milaboratories/helpers@1.14.4': {}
+  '@milaboratories/helpers@1.14.5': {}
 
-  '@milaboratories/pf-driver@1.8.2(@bytecodealliance/preview2-shim@0.17.9)':
+  '@milaboratories/pf-driver@1.9.1(@bytecodealliance/preview2-shim@0.17.9)':
     dependencies:
-      '@milaboratories/helpers': 1.14.4
-      '@milaboratories/pframes-rs-node': 1.1.55
-      '@milaboratories/pframes-rs-wasm': 1.1.55(@bytecodealliance/preview2-shim@0.17.9)(@milaboratories/pl-model-common@1.47.1)(@milaboratories/pl-model-middle-layer@1.30.13)
-      '@milaboratories/pl-model-common': 1.47.1
-      '@milaboratories/pl-model-middle-layer': 1.30.13
-      '@milaboratories/ts-helpers': 1.8.5
+      '@milaboratories/helpers': 1.14.5
+      '@milaboratories/pf-spec': 1.0.1(@bytecodealliance/preview2-shim@0.17.9)
+      '@milaboratories/pframes-rs-node': 1.1.56
+      '@milaboratories/pl-model-common': 1.48.0
+      '@milaboratories/pl-model-middle-layer': 1.32.0
+      '@milaboratories/ts-helpers': 1.8.6
       es-toolkit: 1.42.0
       lru-cache: 11.2.4
     transitivePeerDependencies:
@@ -6299,28 +6316,33 @@ snapshots:
       - encoding
       - supports-color
 
-  '@milaboratories/pf-spec-driver@1.4.21(@bytecodealliance/preview2-shim@0.17.9)':
+  '@milaboratories/pf-spec-driver@1.5.1(@bytecodealliance/preview2-shim@0.17.9)':
     dependencies:
-      '@milaboratories/helpers': 1.14.4
-      '@milaboratories/pframes-rs-wasm': 1.1.55(@bytecodealliance/preview2-shim@0.17.9)(@milaboratories/pl-model-common@1.47.1)(@milaboratories/pl-model-middle-layer@1.30.13)
-      '@milaboratories/pl-model-common': 1.47.1
-      '@milaboratories/pl-model-middle-layer': 1.30.13
+      '@milaboratories/helpers': 1.14.5
+      '@milaboratories/pf-spec': 1.0.1(@bytecodealliance/preview2-shim@0.17.9)
+      '@milaboratories/pl-model-common': 1.48.0
       '@noble/hashes': 2.0.1
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
 
-  '@milaboratories/pframes-rs-node@1.1.55':
+  '@milaboratories/pf-spec@1.0.1(@bytecodealliance/preview2-shim@0.17.9)':
+    dependencies:
+      '@bytecodealliance/preview2-shim': 0.17.9
+      '@milaboratories/pl-model-common': 1.48.0
+      '@milaboratories/pl-model-middle-layer': 1.32.0
+
+  '@milaboratories/pframes-rs-node@1.1.56':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-serv': 1.1.55
+      '@milaboratories/pframes-rs-serv': 1.1.56
       '@milaboratories/pl-model-common': 1.46.2
       ulid: 3.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@milaboratories/pframes-rs-serv@1.1.55':
+  '@milaboratories/pframes-rs-serv@1.1.56':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-model-common': 1.46.2
@@ -6329,24 +6351,15 @@ snapshots:
       commander: 14.0.3
       selfsigned: 5.5.0
 
-  '@milaboratories/pframes-rs-wasip2@1.1.55': {}
-
   '@milaboratories/pframes-rs-wasip2@1.1.56': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.55(@bytecodealliance/preview2-shim@0.17.9)(@milaboratories/pl-model-common@1.47.1)(@milaboratories/pl-model-middle-layer@1.30.13)':
+  '@milaboratories/pl-client@3.14.7':
     dependencies:
-      '@bytecodealliance/preview2-shim': 0.17.9
-      '@milaboratories/pframes-rs-wasip2': 1.1.55
-      '@milaboratories/pl-model-common': 1.47.1
-      '@milaboratories/pl-model-middle-layer': 1.30.13
-
-  '@milaboratories/pl-client@3.14.2':
-    dependencies:
-      '@grpc/grpc-js': 1.13.4
+      '@grpc/grpc-js': 1.14.4
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.47.1
-      '@milaboratories/ts-helpers': 1.8.5
-      '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
+      '@milaboratories/pl-model-common': 1.48.0
+      '@milaboratories/ts-helpers': 1.8.6
+      '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.14.4)
       '@protobuf-ts/runtime': 2.11.1
       '@protobuf-ts/runtime-rpc': 2.11.1
       canonicalize: 2.1.0
@@ -6358,19 +6371,19 @@ snapshots:
       utility-types: 3.11.0
       yaml: 2.8.2
 
-  '@milaboratories/pl-config@1.8.4':
+  '@milaboratories/pl-config@1.8.5':
     dependencies:
-      '@milaboratories/ts-helpers': 1.8.5
+      '@milaboratories/ts-helpers': 1.8.6
       upath: 2.0.1
       yaml: 2.8.2
 
-  '@milaboratories/pl-deployments@3.0.12':
+  '@milaboratories/pl-deployments@3.0.16':
     dependencies:
-      '@milaboratories/pl-config': 1.8.4
-      '@milaboratories/pl-healthcheck': 1.0.3
+      '@milaboratories/pl-config': 1.8.5
+      '@milaboratories/pl-healthcheck': 1.0.5
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.47.1
-      '@milaboratories/ts-helpers': 1.8.5
+      '@milaboratories/pl-model-common': 1.48.0
+      '@milaboratories/ts-helpers': 1.8.6
       decompress: 4.2.1
       ssh2: 1.17.0
       tar: 7.5.2
@@ -6379,16 +6392,16 @@ snapshots:
       yaml: 2.8.2
       zod: 3.25.76
 
-  '@milaboratories/pl-drivers@1.16.10':
+  '@milaboratories/pl-drivers@1.16.16':
     dependencies:
-      '@grpc/grpc-js': 1.13.4
-      '@milaboratories/computable': 2.9.7
-      '@milaboratories/helpers': 1.14.4
-      '@milaboratories/pl-client': 3.14.2
-      '@milaboratories/pl-model-common': 1.47.1
-      '@milaboratories/pl-tree': 1.13.1
-      '@milaboratories/ts-helpers': 1.8.5
-      '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
+      '@grpc/grpc-js': 1.14.4
+      '@milaboratories/computable': 2.9.8
+      '@milaboratories/helpers': 1.14.5
+      '@milaboratories/pl-client': 3.14.7
+      '@milaboratories/pl-model-common': 1.48.0
+      '@milaboratories/pl-tree': 1.13.7
+      '@milaboratories/ts-helpers': 1.8.6
+      '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.14.4)
       '@protobuf-ts/plugin': 2.11.1
       '@protobuf-ts/runtime': 2.11.1
       '@protobuf-ts/runtime-rpc': 2.11.1
@@ -6410,17 +6423,17 @@ snapshots:
       json-stringify-safe: 5.0.1
       zod: 3.25.76
 
-  '@milaboratories/pl-errors@1.4.31':
+  '@milaboratories/pl-errors@1.4.36':
     dependencies:
-      '@milaboratories/pl-client': 3.14.2
-      '@milaboratories/ts-helpers': 1.8.5
+      '@milaboratories/pl-client': 3.14.7
+      '@milaboratories/ts-helpers': 1.8.6
       zod: 3.25.76
 
-  '@milaboratories/pl-healthcheck@1.0.3':
+  '@milaboratories/pl-healthcheck@1.0.5':
     dependencies:
-      '@grpc/grpc-js': 1.13.4
-      '@milaboratories/ts-helpers': 1.8.5
-      '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
+      '@grpc/grpc-js': 1.14.4
+      '@milaboratories/ts-helpers': 1.8.6
+      '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.14.4)
       '@protobuf-ts/runtime': 2.11.1
       '@protobuf-ts/runtime-rpc': 2.11.1
 
@@ -6428,34 +6441,33 @@ snapshots:
     dependencies:
       undici: 7.16.0
 
-  '@milaboratories/pl-middle-layer@1.66.4(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)':
+  '@milaboratories/pl-middle-layer@1.67.0(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)':
     dependencies:
-      '@milaboratories/columns-collection-driver': 0.2.1
-      '@milaboratories/computable': 2.9.7
-      '@milaboratories/helpers': 1.14.4
-      '@milaboratories/pf-driver': 1.8.2(@bytecodealliance/preview2-shim@0.17.9)
-      '@milaboratories/pf-spec-driver': 1.4.21(@bytecodealliance/preview2-shim@0.17.9)
-      '@milaboratories/pframes-rs-node': 1.1.55
-      '@milaboratories/pframes-rs-wasm': 1.1.55(@bytecodealliance/preview2-shim@0.17.9)(@milaboratories/pl-model-common@1.47.1)(@milaboratories/pl-model-middle-layer@1.30.13)
-      '@milaboratories/pl-client': 3.14.2
-      '@milaboratories/pl-deployments': 3.0.12
-      '@milaboratories/pl-drivers': 1.16.10
-      '@milaboratories/pl-errors': 1.4.31
+      '@milaboratories/columns-collection-driver': 0.2.4
+      '@milaboratories/computable': 2.9.8
+      '@milaboratories/helpers': 1.14.5
+      '@milaboratories/pf-driver': 1.9.1(@bytecodealliance/preview2-shim@0.17.9)
+      '@milaboratories/pf-spec-driver': 1.5.1(@bytecodealliance/preview2-shim@0.17.9)
+      '@milaboratories/pframes-rs-node': 1.1.56
+      '@milaboratories/pl-client': 3.14.7
+      '@milaboratories/pl-deployments': 3.0.16
+      '@milaboratories/pl-drivers': 1.16.16
+      '@milaboratories/pl-errors': 1.4.36
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.4.16
-      '@milaboratories/pl-model-common': 1.47.1
-      '@milaboratories/pl-model-middle-layer': 1.30.13
-      '@milaboratories/pl-tree': 1.13.1
+      '@milaboratories/pl-model-backend': 1.4.21
+      '@milaboratories/pl-model-common': 1.48.0
+      '@milaboratories/pl-model-middle-layer': 1.32.0
+      '@milaboratories/pl-tree': 1.13.7
       '@milaboratories/resolve-helper': 1.1.3
-      '@milaboratories/ts-helpers': 1.8.5
-      '@platforma-sdk/block-tools': 2.12.7(@types/node@24.10.2)
-      '@platforma-sdk/model': 1.80.2
-      '@platforma-sdk/workflow-tengo': 6.7.2
+      '@milaboratories/ts-helpers': 1.8.6
+      '@platforma-sdk/block-tools': 2.14.0(@types/node@24.10.2)
+      '@platforma-sdk/model': 1.82.0
+      '@platforma-sdk/workflow-tengo': 6.8.2
       canonicalize: 2.1.0
       denque: 2.1.0
       es-toolkit: 1.42.0
       lru-cache: 11.2.4
-      quickjs-emscripten: 0.31.0
+      quickjs-emscripten: 0.32.0
       semver: 7.7.3
       undici: 7.16.0
       utility-types: 3.11.0
@@ -6471,9 +6483,9 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@milaboratories/pl-model-backend@1.4.16':
+  '@milaboratories/pl-model-backend@1.4.21':
     dependencies:
-      '@milaboratories/pl-client': 3.14.2
+      '@milaboratories/pl-client': 3.14.7
       canonicalize: 2.1.0
       zod: 3.25.76
 
@@ -6484,20 +6496,12 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-common@1.47.1':
+  '@milaboratories/pl-model-common@1.48.0':
     dependencies:
-      '@milaboratories/helpers': 1.14.4
+      '@milaboratories/helpers': 1.14.5
       '@milaboratories/pl-error-like': 1.12.10
       canonicalize: 2.1.0
       es-toolkit: 1.42.0
-      zod: 3.25.76
-
-  '@milaboratories/pl-model-middle-layer@1.30.13':
-    dependencies:
-      '@milaboratories/helpers': 1.14.4
-      '@milaboratories/pl-model-common': 1.47.1
-      es-toolkit: 1.42.0
-      utility-types: 3.11.0
       zod: 3.25.76
 
   '@milaboratories/pl-model-middle-layer@1.30.7':
@@ -6508,19 +6512,27 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/pl-tree@1.13.1':
+  '@milaboratories/pl-model-middle-layer@1.32.0':
     dependencies:
-      '@milaboratories/computable': 2.9.7
-      '@milaboratories/pl-client': 3.14.2
-      '@milaboratories/pl-errors': 1.4.31
-      '@milaboratories/ts-helpers': 1.8.5
+      '@milaboratories/helpers': 1.14.5
+      '@milaboratories/pl-model-common': 1.48.0
+      es-toolkit: 1.42.0
+      utility-types: 3.11.0
+      zod: 3.25.76
+
+  '@milaboratories/pl-tree@1.13.7':
+    dependencies:
+      '@milaboratories/computable': 2.9.8
+      '@milaboratories/pl-client': 3.14.7
+      '@milaboratories/pl-errors': 1.4.36
+      '@milaboratories/ts-helpers': 1.8.6
       denque: 2.1.0
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/ptabler-expression-js@1.2.35':
+  '@milaboratories/ptabler-expression-js@1.2.38':
     dependencies:
-      '@platforma-open/milaboratories.software-ptabler.schema': 1.15.19
+      '@platforma-open/milaboratories.software-ptabler.schema': 1.15.22
 
   '@milaboratories/resolve-helper@1.1.3': {}
 
@@ -6528,9 +6540,9 @@ snapshots:
 
   '@milaboratories/tengo-tester@1.6.4': {}
 
-  '@milaboratories/ts-builder@1.6.0(@types/node@24.10.2)(rollup@4.53.3)(vue@3.5.24(typescript@5.9.3))(yaml@2.8.2)':
+  '@milaboratories/ts-builder@1.7.0(@types/node@24.10.2)(rollup@4.53.3)(vue@3.5.24(typescript@5.9.3))(yaml@2.8.2)':
     dependencies:
-      '@milaboratories/ts-configs': 1.3.0
+      '@milaboratories/ts-configs': 1.4.0
       '@vitejs/plugin-vue': 6.0.5(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))(vue@3.5.24(typescript@5.9.3))
       commander: 15.0.0
       jsonc-parser: 3.3.1
@@ -6569,9 +6581,9 @@ snapshots:
       - vue
       - yaml
 
-  '@milaboratories/ts-builder@1.6.0(@types/node@24.10.2)(rollup@4.53.3)(vue@3.5.25(typescript@5.6.3))(yaml@2.8.2)':
+  '@milaboratories/ts-builder@1.7.0(@types/node@24.10.2)(rollup@4.53.3)(vue@3.5.25(typescript@5.6.3))(yaml@2.8.2)':
     dependencies:
-      '@milaboratories/ts-configs': 1.3.0
+      '@milaboratories/ts-configs': 1.4.0
       '@vitejs/plugin-vue': 6.0.5(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))(vue@3.5.25(typescript@5.6.3))
       commander: 15.0.0
       jsonc-parser: 3.3.1
@@ -6610,9 +6622,9 @@ snapshots:
       - vue
       - yaml
 
-  '@milaboratories/ts-builder@1.6.0(@types/node@24.10.2)(rollup@4.53.3)(vue@3.5.25(typescript@5.9.3))(yaml@2.8.2)':
+  '@milaboratories/ts-builder@1.7.0(@types/node@24.10.2)(rollup@4.53.3)(vue@3.5.25(typescript@5.9.3))(yaml@2.8.2)':
     dependencies:
-      '@milaboratories/ts-configs': 1.3.0
+      '@milaboratories/ts-configs': 1.4.0
       '@vitejs/plugin-vue': 6.0.5(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))(vue@3.5.25(typescript@5.9.3))
       commander: 15.0.0
       jsonc-parser: 3.3.1
@@ -6651,18 +6663,18 @@ snapshots:
       - vue
       - yaml
 
-  '@milaboratories/ts-configs@1.3.0': {}
+  '@milaboratories/ts-configs@1.4.0': {}
 
-  '@milaboratories/ts-helpers@1.8.5':
+  '@milaboratories/ts-helpers@1.8.6':
     dependencies:
-      '@milaboratories/helpers': 1.14.4
+      '@milaboratories/helpers': 1.14.5
       canonicalize: 2.1.0
       denque: 2.1.0
 
-  '@milaboratories/uikit@2.15.16(typescript@5.9.3)':
+  '@milaboratories/uikit@2.15.24(typescript@5.9.3)':
     dependencies:
-      '@milaboratories/helpers': 1.14.4
-      '@platforma-sdk/model': 1.80.2
+      '@milaboratories/helpers': 1.14.5
+      '@platforma-sdk/model': 1.82.0
       '@types/d3-array': 3.2.2
       '@types/d3-axis': 3.0.6
       '@types/d3-scale': 4.0.9
@@ -6693,17 +6705,17 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
-    dependencies:
-      '@emnapi/core': 1.9.1
-      '@emnapi/runtime': 1.9.1
-      '@tybys/wasm-util': 0.10.1
-    optional: true
-
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
+    dependencies:
+      '@emnapi/core': 1.9.1
+      '@emnapi/runtime': 1.9.1
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -6964,15 +6976,11 @@ snapshots:
 
   '@platforma-open/milaboratories.software-mixcr@4.7.0-347-develop': {}
 
-  '@platforma-open/milaboratories.software-ptabler.schema@1.15.19':
+  '@platforma-open/milaboratories.software-ptabler.schema@1.15.22':
     dependencies:
-      '@milaboratories/pl-model-common': 1.47.1
-
-  '@platforma-open/milaboratories.software-ptabler@2.1.6': {}
+      '@milaboratories/pl-model-common': 1.48.0
 
   '@platforma-open/milaboratories.software-ptabler@2.1.8': {}
-
-  '@platforma-open/milaboratories.software-ptexter@1.2.3': {}
 
   '@platforma-open/milaboratories.software-ptexter@1.2.4': {}
 
@@ -6994,19 +7002,21 @@ snapshots:
       '@platforma-open/milaboratories.software-small-binaries.mnz-client': 1.6.5
       '@platforma-open/milaboratories.software-small-binaries.table-converter': 1.3.5
 
-  '@platforma-sdk/block-tools@2.12.7(@types/node@24.10.2)':
+  '@platforma-sdk/block-kind@1.1.0': {}
+
+  '@platforma-sdk/block-tools@2.14.0(@types/node@24.10.2)':
     dependencies:
       '@aws-sdk/client-ecr-public': 3.859.0
       '@aws-sdk/client-s3': 3.859.0
       '@inquirer/prompts': 7.10.1(@types/node@24.10.2)
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.4.16
-      '@milaboratories/pl-model-common': 1.47.1
-      '@milaboratories/pl-model-middle-layer': 1.30.13
+      '@milaboratories/pl-model-backend': 1.4.21
+      '@milaboratories/pl-model-common': 1.48.0
+      '@milaboratories/pl-model-middle-layer': 1.32.0
       '@milaboratories/resolve-helper': 1.1.3
-      '@milaboratories/ts-helpers': 1.8.5
+      '@milaboratories/ts-helpers': 1.8.6
       '@platforma-sdk/blocks-deps-updater': 2.2.0
-      '@platforma-sdk/package-builder-lib': 1.2.0
+      '@platforma-sdk/package-builder-lib': 1.3.0
       canonicalize: 2.1.0
       commander: 15.0.0
       lru-cache: 11.2.4
@@ -7025,13 +7035,13 @@ snapshots:
     dependencies:
       yaml: 2.8.2
 
-  '@platforma-sdk/model@1.80.2':
+  '@platforma-sdk/model@1.82.0':
     dependencies:
-      '@milaboratories/helpers': 1.14.4
+      '@milaboratories/helpers': 1.14.5
       '@milaboratories/pl-error-like': 1.12.10
-      '@milaboratories/pl-model-common': 1.47.1
-      '@milaboratories/pl-model-middle-layer': 1.30.13
-      '@milaboratories/ptabler-expression-js': 1.2.35
+      '@milaboratories/pl-model-common': 1.48.0
+      '@milaboratories/pl-model-middle-layer': 1.32.0
+      '@milaboratories/ptabler-expression-js': 1.2.38
       canonicalize: 2.1.0
       es-toolkit: 1.42.0
       fast-json-patch: 3.1.1
@@ -7039,7 +7049,7 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@platforma-sdk/package-builder-lib@1.2.0':
+  '@platforma-sdk/package-builder-lib@1.3.0':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
       '@aws-sdk/lib-storage': 3.859.0(@aws-sdk/client-s3@3.859.0)
@@ -7054,24 +7064,24 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  '@platforma-sdk/tengo-builder@4.0.18':
+  '@platforma-sdk/tengo-builder@4.0.23':
     dependencies:
-      '@milaboratories/pl-model-backend': 1.4.16
+      '@milaboratories/pl-model-backend': 1.4.21
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/tengo-tester': 1.6.4
-      '@milaboratories/ts-helpers': 1.8.5
+      '@milaboratories/ts-helpers': 1.8.6
       commander: 15.0.0
       winston: 3.19.0
 
-  '@platforma-sdk/test@1.80.5(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))':
+  '@platforma-sdk/test@1.82.0(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))':
     dependencies:
-      '@milaboratories/computable': 2.9.7
-      '@milaboratories/pl-client': 3.14.2
-      '@milaboratories/pl-middle-layer': 1.66.4(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)
-      '@milaboratories/pl-tree': 1.13.1
-      '@platforma-sdk/model': 1.80.2
-      '@vitest/coverage-istanbul': 4.1.3(vitest@4.0.18(@types/node@24.10.2)(lightningcss@1.32.0)(yaml@2.8.2))
-      vitest: 4.1.3(@types/node@24.10.2)(@vitest/coverage-istanbul@4.1.3)(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))
+      '@milaboratories/computable': 2.9.8
+      '@milaboratories/pl-client': 3.14.7
+      '@milaboratories/pl-middle-layer': 1.67.0(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)
+      '@milaboratories/pl-tree': 1.13.7
+      '@platforma-sdk/model': 1.82.0
+      '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3)
+      vitest: 4.1.3(@types/node@24.10.2)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.18(@types/node@24.10.2)(lightningcss@1.32.0)(yaml@2.8.2)))(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
       - '@edge-runtime/vm'
@@ -7093,13 +7103,13 @@ snapshots:
       - supports-color
       - vite
 
-  '@platforma-sdk/ui-vue@1.80.4(@bytecodealliance/preview2-shim@0.17.9)(typescript@5.9.3)':
+  '@platforma-sdk/ui-vue@1.82.1(@bytecodealliance/preview2-shim@0.17.9)(typescript@5.9.3)':
     dependencies:
-      '@milaboratories/columns-collection-driver': 0.2.1
-      '@milaboratories/pf-spec-driver': 1.4.21(@bytecodealliance/preview2-shim@0.17.9)
-      '@milaboratories/pl-model-common': 1.47.1
-      '@milaboratories/uikit': 2.15.16(typescript@5.9.3)
-      '@platforma-sdk/model': 1.80.2
+      '@milaboratories/columns-collection-driver': 0.2.4
+      '@milaboratories/pf-spec-driver': 1.5.1(@bytecodealliance/preview2-shim@0.17.9)
+      '@milaboratories/pl-model-common': 1.48.0
+      '@milaboratories/uikit': 2.15.24(typescript@5.9.3)
+      '@platforma-sdk/model': 1.82.0
       '@types/d3-format': 3.0.4
       '@types/node': 24.5.2
       '@types/semver': 7.7.1
@@ -7130,14 +7140,6 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@platforma-sdk/workflow-tengo@6.7.2':
-    dependencies:
-      '@milaboratories/pframes-rs-wasip2': 1.1.55
-      '@milaboratories/software-pframes-conv': 2.2.9
-      '@platforma-open/milaboratories.software-ptabler': 2.1.6
-      '@platforma-open/milaboratories.software-ptexter': 1.2.3
-      '@platforma-open/milaboratories.software-small-binaries': 2.1.1
-
   '@platforma-sdk/workflow-tengo@6.8.2':
     dependencies:
       '@milaboratories/pframes-rs-wasip2': 1.1.56
@@ -7146,9 +7148,9 @@ snapshots:
       '@platforma-open/milaboratories.software-ptexter': 1.2.4
       '@platforma-open/milaboratories.software-small-binaries': 2.1.1
 
-  '@protobuf-ts/grpc-transport@2.11.1(@grpc/grpc-js@1.13.4)':
+  '@protobuf-ts/grpc-transport@2.11.1(@grpc/grpc-js@1.14.4)':
     dependencies:
-      '@grpc/grpc-js': 1.13.4
+      '@grpc/grpc-js': 1.14.4
       '@protobuf-ts/runtime': 2.11.1
       '@protobuf-ts/runtime-rpc': 2.11.1
 
@@ -7175,24 +7177,21 @@ snapshots:
 
   '@protobufjs/base64@1.1.2': {}
 
-  '@protobufjs/codegen@2.0.4': {}
+  '@protobufjs/codegen@2.0.5': {}
 
-  '@protobufjs/eventemitter@1.1.0': {}
+  '@protobufjs/eventemitter@1.1.1': {}
 
-  '@protobufjs/fetch@1.1.0':
+  '@protobufjs/fetch@1.1.1':
     dependencies:
       '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/inquire': 1.1.0
 
   '@protobufjs/float@1.0.2': {}
-
-  '@protobufjs/inquire@1.1.0': {}
 
   '@protobufjs/path@1.1.2': {}
 
   '@protobufjs/pool@1.1.0': {}
 
-  '@protobufjs/utf8@1.1.0': {}
+  '@protobufjs/utf8@1.1.2': {}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.13':
     optional: true
@@ -7270,7 +7269,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.9.1
       '@emnapi/runtime': 1.9.1
-      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.1.3':
@@ -7764,11 +7763,6 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@tybys/wasm-util@0.10.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -7865,7 +7859,7 @@ snapshots:
       vite: 8.0.7(@types/node@24.10.2)(yaml@2.8.2)
       vue: 3.5.25(typescript@5.9.3)
 
-  '@vitest/coverage-istanbul@4.1.3(vitest@4.0.18(@types/node@24.10.2)(lightningcss@1.32.0)(yaml@2.8.2))':
+  '@vitest/coverage-istanbul@4.1.3(vitest@4.1.3)':
     dependencies:
       '@babel/core': 7.29.0
       '@istanbuljs/schema': 0.1.3
@@ -7877,7 +7871,7 @@ snapshots:
       magicast: 0.5.2
       obug: 2.1.3
       tinyrainbow: 3.1.0
-      vitest: 4.0.18(@types/node@24.10.2)(lightningcss@1.32.0)(yaml@2.8.2)
+      vitest: 4.1.3(@types/node@24.10.2)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.18(@types/node@24.10.2)(lightningcss@1.32.0)(yaml@2.8.2)))(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -9671,18 +9665,17 @@ snapshots:
 
   proto-list@1.2.4: {}
 
-  protobufjs@7.5.4:
+  protobufjs@7.6.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
       '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
+      '@protobufjs/utf8': 1.1.2
       '@types/node': 24.10.2
       long: 5.3.2
 
@@ -9703,17 +9696,17 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  quickjs-emscripten-core@0.31.0:
+  quickjs-emscripten-core@0.32.0:
     dependencies:
-      '@jitl/quickjs-ffi-types': 0.31.0
+      '@jitl/quickjs-ffi-types': 0.32.0
 
-  quickjs-emscripten@0.31.0:
+  quickjs-emscripten@0.32.0:
     dependencies:
-      '@jitl/quickjs-wasmfile-debug-asyncify': 0.31.0
-      '@jitl/quickjs-wasmfile-debug-sync': 0.31.0
-      '@jitl/quickjs-wasmfile-release-asyncify': 0.31.0
-      '@jitl/quickjs-wasmfile-release-sync': 0.31.0
-      quickjs-emscripten-core: 0.31.0
+      '@jitl/quickjs-wasmfile-debug-asyncify': 0.32.0
+      '@jitl/quickjs-wasmfile-debug-sync': 0.32.0
+      '@jitl/quickjs-wasmfile-release-asyncify': 0.32.0
+      '@jitl/quickjs-wasmfile-release-sync': 0.32.0
+      quickjs-emscripten-core: 0.32.0
 
   rc@1.2.8:
     dependencies:
@@ -10359,7 +10352,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.3(@types/node@24.10.2)(@vitest/coverage-istanbul@4.1.3)(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2)):
+  vitest@4.1.3(@types/node@24.10.2)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.18(@types/node@24.10.2)(lightningcss@1.32.0)(yaml@2.8.2)))(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.3
       '@vitest/mocker': 4.1.3(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))
@@ -10383,7 +10376,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.2
-      '@vitest/coverage-istanbul': 4.1.3(vitest@4.0.18(@types/node@24.10.2)(lightningcss@1.32.0)(yaml@2.8.2))
+      '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3)
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,10 +14,10 @@ catalog:
   "@platforma-sdk/ui-vue": 1.82.1
   "@platforma-sdk/tengo-builder": 4.0.23
   "@platforma-sdk/package-builder": 3.15.0
-  "@platforma-sdk/block-tools": 2.14.0
+  "@platforma-sdk/block-tools": 2.14.2
   "@platforma-sdk/block-kind": 1.1.0
 
-  "@platforma-sdk/test": 1.82.0
+  "@platforma-sdk/test": 1.82.3
   "@milaboratories/helpers": 1.14.5
 
   "@platforma-open/milaboratories.software-mixcr": 4.7.0-347-develop

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,46 +1,50 @@
 packages:
   - block
+  - kind
   - model
   - test
   - ui
   - workflow
 
 catalog:
-  '@milaboratories/ts-builder': 1.6.0
-  '@milaboratories/ts-configs': 1.3.0
-  '@platforma-sdk/workflow-tengo': 6.8.2
-  '@platforma-sdk/model': 1.80.2
-  '@platforma-sdk/ui-vue': 1.80.4
-  '@platforma-sdk/tengo-builder': 4.0.18
-  '@platforma-sdk/package-builder': 3.14.1
-  '@platforma-sdk/block-tools': 2.12.7
+  "@milaboratories/ts-builder": 1.7.0
+  "@milaboratories/ts-configs": 1.4.0
+  "@platforma-sdk/workflow-tengo": 6.8.2
+  "@platforma-sdk/model": 1.82.0
+  "@platforma-sdk/ui-vue": 1.82.1
+  "@platforma-sdk/tengo-builder": 4.0.23
+  "@platforma-sdk/package-builder": 3.15.0
+  "@platforma-sdk/block-tools": 2.14.0
+  "@platforma-sdk/block-kind": 1.1.0
 
-  '@platforma-sdk/test': 1.80.5
-  '@milaboratories/helpers': 1.14.4
+  "@platforma-sdk/test": 1.82.0
+  "@milaboratories/helpers": 1.14.5
 
-  '@platforma-open/milaboratories.software-mixcr': 4.7.0-347-develop
-  'vue': 3.5.24
+  "@platforma-open/milaboratories.software-mixcr": 4.7.0-347-develop
+  "vue": 3.5.24
 
-  'zod': ~3.25.76
-  'utility-types': ^3.11.0
+  "zod": ~3.25.76
+  "utility-types": ^3.11.0
+  # pinned to the copy already in the graph, so the kind does not pull a second one
+  "es-toolkit": 1.42.0
 
-  'typescript': ~5.6.3
-  'turbo': ^2.5.8
+  "typescript": ~5.6.3
+  "turbo": ^2.5.8
 
-  'vitest': ^4.0.18
-  'eslint': ^9.38.0
+  "vitest": ^4.0.18
+  "eslint": ^9.38.0
 
-  '@vueuse/core': ^13.6.0
+  "@vueuse/core": ^13.6.0
 
-  'ag-grid-enterprise': &ag-grid ~34.1.2
-  'ag-grid-vue3': *ag-grid
+  "ag-grid-enterprise": &ag-grid ~34.1.2
+  "ag-grid-vue3": *ag-grid
 
-  '@changesets/cli': ^2.29.7
-  'js-yaml': ^4.1.0
-  'shx': ^0.4.0
-  '@zip.js/zip.js': ^2.8.8
-  '@types/wicg-file-system-access': ^2023.10.7
+  "@changesets/cli": ^2.29.7
+  "js-yaml": ^4.1.0
+  "shx": ^0.4.0
+  "@zip.js/zip.js": ^2.8.8
+  "@types/wicg-file-system-access": ^2023.10.7
 
   # other blocks used in tests
 
-  '@platforma-open/milaboratories.samples-and-data': ^1.18.0
+  "@platforma-open/milaboratories.samples-and-data": ^1.18.0


### PR DESCRIPTION
Brings `mixcr-clonotyping` onto the current block structure: it declares the mandatory `kind/` component, and its model moves off the removed and deprecated column-access surface.

## The kind

A block kind is a small, separately versioned package carrying the block's identity and its **init-params contract** — the fields a project template supplies to seed a new instance. `structure check` hard-fails a kind-less block, so this is what unblocks the block on the current structurer.

`BlockParams` covers the analysis recipe, input refs, run mode and resources, and display labels — everything in `BlockData` except `tableState`, which is view state.

Two decisions worth reviewing:

- **Every field is optional.** A block with no input picked and no preset chosen is an ordinary state the UI reaches, so export has to be able to write it and apply has to take it back. A contract demanding `input` would stop export and apply being inverses. Whether a configuration is *runnable* stays gated by the model's `args` lambda.
- **File-valued params are narrowed to `index://` handles.** An `upload://` handle names an import local to one machine, so it cannot survive being written to a template and applied elsewhere. The parser rejects them and `templateParams` drops them, rather than writing a reference that resolves nowhere. This applies to `libraryFile` and to a file-shaped `preset`.

The runtime check is a `CONTRACT` table validated with `satisfies` over `keyof BlockParams`, so adding a field without its guard fails to compile — which matters precisely because every field is optional, and a parser that simply forgot one would otherwise return a valid `BlockParams` and say nothing.

## Column access

Per `migrations/2026-05-20-new-column-access-mechanism.md` and `docs/column-access-api.md`:

| Before | After | Sites |
|---|---|---|
| `ColumnLazy` / `.fromColumn` | `DataColumn`, then dropped entirely | 3 |
| `resultPool.getSpecByRef(ref)` | `Column(ref)?.getSpec()` | 2 |
| `accessor.getPColumns()` | `ColumnsCollection([accessor])` | 3 |

The collection resolves ids host-side, so `clones` and `pt` no longer materialise specs in the sandbox only to hand them straight back. `rawTsvs` also drops its `...pCol` spread — its only consumer (`ui/src/MainPage.vue`) reads `id` and `data` and never touches the spec, so that output now fetches no specs at all.

**Deliberately unchanged:**

- `resultPool.getOptions` (3 sites) — the migration doc says to stay on it: `ctx.getOptions` is not on `RenderCtxBase` yet, and it is the only entry point preserving the `Option[]` = `{ ref, label }` wire shape with `refsWithEnrichments`.
- `sampleLabels` still calls `resultPool.getData()`. This is the real 8 MB anti-pattern and worth fixing, but the axis-domain matching has to be reworked against a discover selector plus a `getSpec()` post-filter, and the data-reading tail needs narrowing off the `PColumnDataUniversal` union. Out of scope here — left for a separate change.

## Verification

- `turbo run build` — 11/11 green.
- `block-tools structure check` — `up to date (0 changes)`, i.e. a fixpoint.
- `pnpm install --frozen-lockfile` — in sync.
- The kind's `parseInitializationParams` exercised against the built `dist/kind.js`: empty params, a template-shaped `{ species, preset }`, an unknown key (dropped), a wrong-typed field, `upload://` vs `index://` handles, a bad enum, and `null` / array envelopes all behave as intended.

No backend run — nothing here changes workflow behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds the mandatory block-kind contract, connects template import/export to model state, and migrates model outputs to the current column-access APIs.
- **Block kind** — a separately versioned package defining block identity and initialization parameters; this PR adds the `kind/` workspace package and connects it to the model and block build.
- **BlockParams** — the typed, runtime-validated initialization contract; this PR covers analysis settings, inputs, resources, run mode, and labels while excluding table view state.
- **Initialization params** — template-supplied values used to seed a block; this PR parses them field-by-field and applies model defaults to omitted values.
- **Template params** — the model projection serialized during template export; this PR exports the initialization fields while dropping machine-local file handles.
- **ImportFileHandleIndex** — a portable `index://` file reference; this PR narrows template file parameters to this type instead of retaining local `upload://` references.
- **ColumnsCollection** — a host-side collection that resolves column identifiers; this PR replaces direct `getPColumns()` calls for clone, QC-table, and raw-TSV outputs.
- **DataColumn** — a column carrying accessible data; this PR uses it to identify raw-TSV columns and retrieve their file resources.
- **Column** — a reference-based column accessor; this PR replaces deprecated result-pool specification lookups with `Column(ref)?.getSpec()`.
- CI and package metadata move to Node.js 22, update Platforma SDK dependencies, require a block-package changeset, and add unstable publishing plus stable-promotion support.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| kind/src/types.ts | Defines the new optional initialization contract and portable file-reference types. |
| kind/src/params.ts | Adds exhaustive runtime guards for every initialization parameter. |
| kind/src/index.ts | Defines the separately versioned block-kind identity and parser. |
| model/src/index.ts | Connects the model to its kind, implements template parameter projection, and migrates column access. |
| block/package.json | Integrates the kind package and introduces unstable publishing and stable-promotion scripts. |
| pnpm-workspace.yaml | Registers the kind package as a workspace member. |
| .github/workflows/build.yaml | Moves CI to Node.js 22 and enforces a changeset bump for the published block package. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  T[Project template] --> P[Kind parameter parser]
  P --> I[Model init]
  I --> D[BlockData]
  D --> A[Runtime args validation]
  D --> E[Template parameter projection]
  E -->|portable index handles only| T
  W[Workflow output trees] --> C[ColumnsCollection / Column]
  C --> O[Clone frame, QC table, labels, raw TSV outputs]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["update node version to 22.x and bump dep..."](https://github.com/platforma-open/mixcr-clonotyping/commit/38eac386c7f8521865cf39d315fc08fa8a074510) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54754943)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->