### PR TITLE
Create README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,97 @@
+# MiXCR Clonotyping
+
+Extract TCR and BCR clonotypes from raw sequencing data. This Platforma block runs MiXCR end to end — alignment against germline gene databases, error correction, receptor assembly, and clonotype grouping — turning FASTQ into a quantified repertoire with full QC. It is the first analysis step in most immune repertoire projects.
+
+Open-source analysis block for Platforma, the biologics discovery platform by MiLaboratories. For the full no-code workflow, see [platforma.bio](https://platforma.bio/).
+
+## What it does
+
+Reads coming off a sequencer are not clonotypes. Getting from one to the other means aligning each read to V, D, J, and C germline genes, correcting PCR and sequencing errors so artifacts are not counted as diversity, assembling the receptor sequence across reads, and grouping identical receptors into clonotypes with quantified abundance. MiXCR does all of that, and this block runs it inside Platforma with the results wired into every downstream analysis.
+
+Configuration starts from a MiXCR preset matching your library chemistry, which sets sensible defaults for the whole pipeline. From there you specify what the data is: species, material type (DNA or RNA), which receptors to extract, and where your primers sit — the 5' and 3' boundary settings tell MiXCR which alignment edges are floating, which matters for correct assembly of primer-bounded amplicons.
+
+You choose the feature clonotypes are assembled by, from CDR3 alone to the full variable region (FR1–FR4) or any range between. That choice propagates: assembling by CDR3 is faster and works with short amplicons, while assembling by the full region is what downstream mutation analysis and SHM tree building require.
+
+UMIs and cell barcodes are extracted with a MiXCR tag pattern, so abundances can be counted per unique molecule rather than per read. Error correction strength is configurable. For display-derived libraries, stop codons can be translated as the residue your suppressor strain incorporates — amber, ochre, or opal, each with its own replacement — so those clonotypes are not discarded as non-productive. A custom reference library can be supplied from a file or from the [MiXCR Library Builder](https://github.com/platforma-open/mixcr-library-builder) block when germline references do not fit.
+
+Results include a per-sample alignment summary that breaks failures down by cause, a QC report table across all samples, per-sample MiXCR reports and logs, and raw TSV export. Preview mode runs the configuration without processing everything, and a per-sample read limit lets you test settings quickly.
+
+## Inputs & outputs
+
+* **Input:** raw sequencing data from [Samples & Data](https://github.com/platforma-open/samples-and-data) — bulk, single-cell, RNA-seq, or Sanger — plus a MiXCR preset and library description.
+* **Output:** a quantified clonotype dataset with per-sample abundances, V/D/J/C gene assignments, and region sequences, consumable by every downstream Platforma block; a QC report table; per-sample reports, logs, and alignment charts; raw TSV export.
+
+## Specifications
+
+| | |
+|---|---|
+| Block title in app | MiXCR Clonotyping |
+| Engine | [MiXCR](https://mixcr.com/) — germline-database alignment, error correction, assembly, clonotyping |
+| Data types | Bulk, single-cell, RNA-seq, Sanger |
+| Species | Homo sapiens, Mus musculus, Alpaca, Lama glama, Macaca fascicularis, Macaca mulatta, Rabbit, Rat, Sheep, Chicken, Spalax |
+| Material type | DNA or RNA |
+| Assembling feature | CDR3, VDJRegion (FR1–FR4), or any range such as `CDR1–CDR3`, `FR2–FR4`, `FR3–CDR3` |
+| Primer boundaries | Configurable 5' and 3' alignment boundaries, including C-primer libraries |
+| UMI / barcodes | MiXCR tag pattern, for UMI-corrected abundances |
+| Stop codon handling | Amber (TAG), Ochre (TAA), Opal/Umber (TGA), each with a configurable replacement residue |
+| Reference library | Built-in germline references, or a custom library from file or MiXCR Library Builder |
+| Other settings | Error correction strength, per-sample read limit, preview mode, per-sample memory and CPU |
+
+## Use cases
+
+* **Repertoire profiling:** quantify TCR or BCR clonotypes from bulk sequencing to characterize diversity and composition.
+* **Single-cell VDJ:** extract paired-chain clonotypes from single-cell libraries.
+* **Antibody discovery:** build the clonotype dataset that clustering, enrichment, developability, and lead selection all run on.
+* **UMI-corrected quantification:** extract UMIs so clonotype frequencies reflect molecules rather than amplification.
+* **Kit-based workflows:** start from the MiXCR preset matching your commercial kit rather than configuring the pipeline by hand.
+* **Non-human species:** profile repertoires in mouse, alpaca, macaque, rabbit, rat, sheep, chicken, and more.
+* **SHM lineage work:** assemble by the full variable region so [MiXCR SHM Trees](https://github.com/platforma-open/mixcr-shm-trees) can build lineage trees from the result.
+
+## How it compares to other Platforma blocks
+
+* **MiXCR Clonotyping** aligns to germline gene databases to discover clonotypes in natural repertoires.
+* **[MiXCR Amplicon Alignment](https://github.com/platforma-open/mixcr-amplicon-alignment)** aligns to a reference construct you supply — for synthetic libraries built on a known scaffold.
+* **[MiXCR scFv Alignment](https://github.com/platforma-open/mixcr-scfv-clonotyping)** handles scFv constructs where heavy and light chains sit in a single amplicon.
+* **[Import V(D)J Data](https://github.com/platforma-open/import-vdj-data)** skips clonotyping entirely, loading clonotype tables produced elsewhere.
+
+## FAQ
+
+### Which preset should I use?
+
+The one matching your library chemistry — commercial kits have named presets, and the preset sets defaults across the whole pipeline. Getting this right matters more than any individual setting, since it encodes the assumptions about how the library was built.
+
+### Which assembling feature should I choose?
+
+CDR3 is fastest and works with short amplicons, but limits downstream analysis. The full variable region (FR1–FR4) is required for mutation analysis, SHM tree building, humanness scoring, and structure prediction. If your amplicon covers the full region, assemble by it — several downstream blocks will otherwise reject the dataset.
+
+### How do I get UMI-corrected counts?
+
+Supply a MiXCR tag pattern describing where the UMI sits in your reads. Abundances are then counted per unique molecule instead of per read, which removes amplification bias. See the [MiXCR tag pattern reference](https://mixcr.com/mixcr/reference/ref-tag-pattern/).
+
+### Why are there stop codon settings?
+
+Display libraries are often propagated in suppressor strains that read a stop codon as an amino acid. Without this setting those clonotypes are discarded as non-productive. Selecting the codon and its replacement residue keeps them in the analysis.
+
+### My alignment rate is low — what should I check?
+
+The per-sample alignment summary breaks failures down by cause. Low scores or missing gene hits usually mean the preset, species, or primer boundaries do not match the library. Failures on "no barcode" point at a tag pattern that does not match the actual read layout.
+
+### Can I use my own reference library?
+
+Yes. Supply a custom library from a file, or build one with the MiXCR Library Builder block — useful for species or engineered constructs the built-in germline references do not cover.
+
+### Do I need a MiXCR license?
+
+Yes. MiXCR requires a license key, which is [free for academic scientists, PhD students, and non-profit R&D centers](https://platforma.bio/academic-access); commercial use requires a business license. Keys are available at [platforma.bio/getlicense](https://platforma.bio/getlicense).
+
+## Citation
+
+MiXCR is developed by MiLaboratories Inc. If you use this block in your research, please cite:
+
+> Bolotin, D. A., Poslavsky, S., Mitrophanov, I., Shugay, M., Mamedov, I. Z., Putintseva, E. V., & Chudakov, D. M. (2015). MiXCR: software for comprehensive adaptive immunity profiling. *Nature Methods* **12**(5), 380–381. [https://doi.org/10.1038/nmeth.3364](https://doi.org/10.1038/nmeth.3364)
+
+> Bolotin, D. A., Poslavsky, S., Davydov, A. N., et al. (2017). Antigen receptor repertoire profiling from RNA-seq data. *Nature Biotechnology* **35**(10), 908–911. [https://doi.org/10.1038/nbt.3979](https://doi.org/10.1038/nbt.3979)
+
+## Part of the Platforma ecosystem
+
+This block is part of [Platforma](https://platforma.bio/) by [MiLaboratories](https://github.com/milaboratory), built on [MiXCR](https://mixcr.com/). Explore the other open-source blocks at [github.com/platforma-open](https://github.com/platforma-open) and the docs for V(D)J analysis at [docs.platforma.bio/biology-guides/vdj-analysis](https://docs.platforma.bio/biology-guides/vdj-analysis/).


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a comprehensive README describing the MiXCR Clonotyping block, its configuration, outputs, use cases, operational guidance, licensing, and citations. One UMI configuration statement overstates what supplying a tag pattern alone enables.

- **Clonotype** — A grouped receptor sequence with quantified abundance; the README introduces the block’s clonotype extraction and downstream usage.
- **MiXCR preset** — A predefined pipeline configuration for a library chemistry; the README explains preset selection and its role in supplying pipeline defaults.
- **Assembling feature** — The receptor-region span used to form clonotypes, such as CDR3 or VDJRegion; the README documents available ranges and downstream implications.
- **UMI** — A unique molecular identifier used to distinguish original molecules from PCR duplicates; the README adds setup and counting guidance, but should clarify that the preset must also declare UMI tags.
- **Tag pattern** — A MiXCR expression describing barcode and UMI positions in reads; the README introduces it as the mechanism for extracting those tags.
- **Primer boundary** — The configurable alignment edge associated with primer placement; the README explains its relevance to primer-bounded amplicons.
- **Custom reference library** — A user-supplied germline reference set; the README documents file-based and MiXCR Library Builder sources.
- **Stop-codon replacement** — Translation of amber, ochre, or opal codons to configured residues for suppressor-strain libraries; the README documents the feature and its purpose.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The UMI guidance should be corrected before merging because it can cause users to mistake read-based output for molecule-corrected abundance.

The implementation passes custom tag patterns to MiXCR but gates unique-molecule output fields on UMI metadata from the selected preset, while the new README presents the tag pattern alone as sufficient.

**Files Needing Attention:** README.md
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Adds user-facing documentation for the block; most claims align with implementation, but the UMI FAQ omits the preset metadata prerequisite for molecule-count outputs. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20platforma-open%2Fmixcr-clonotyping%20PR%20%23212%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=platforma-open%2Fmixcr-clonotyping&pr=212&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0AREADME.md%3A69%0A**Tag%20pattern%20alone%20lacks%20UMI%20counts**%0A%0AWhen%20a%20user%20supplies%20a%20UMI%20tag%20pattern%20with%20a%20preset%20that%20does%20not%20declare%20%60umiTags%60%2C%20the%20export%20still%20omits%20%60uniqueMoleculeCount%60%20and%20%60uniqueMoleculeFraction%60%2C%20so%20this%20guidance%20can%20cause%20read-based%20abundance%20to%20be%20mistaken%20for%20molecule-corrected%20output.%0A%0A%60%60%60suggestion%0ASelect%20a%20UMI-aware%20preset%20and%20supply%20a%20MiXCR%20tag%20pattern%20describing%20where%20the%20UMI%20sits%20in%20your%20reads.%20When%20the%20preset%20declares%20UMI%20tags%2C%20the%20output%20includes%20unique-molecule%20counts%20and%20fractions%20rather%20than%20only%20read-based%20abundances.%20See%20the%20%5BMiXCR%20tag%20pattern%20reference%5D%28https%3A%2F%2Fmixcr.com%2Fmixcr%2Freference%2Fref-tag-pattern%2F%29.%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=platforma-open%2Fmixcr-clonotyping&pr=212&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:69
**Tag pattern alone lacks UMI counts**

When a user supplies a UMI tag pattern with a preset that does not declare `umiTags`, the export still omits `uniqueMoleculeCount` and `uniqueMoleculeFraction`, so this guidance can cause read-based abundance to be mistaken for molecule-corrected output.

```suggestion
Select a UMI-aware preset and supply a MiXCR tag pattern describing where the UMI sits in your reads. When the preset declares UMI tags, the output includes unique-molecule counts and fractions rather than only read-based abundances. See the [MiXCR tag pattern reference](https://mixcr.com/mixcr/reference/ref-tag-pattern/).
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Create README.md"](https://github.com/platforma-open/mixcr-clonotyping/commit/5f062626292fe9d3e640c915596b50cc8a332c56) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55549316)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->